### PR TITLE
Fix mypy configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,3 +81,6 @@ show_traceback = True
 pretty = True
 plugins = pydantic.mypy
 exclude = _version\.py
+
+[mypy-tinuous._version]
+follow_imports = skip


### PR DESCRIPTION
This PR configures mypy to properly ignore `_version.py`, thus allowing the typing tests to pass again.