### PR TITLE
Support reading env vars from .env files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,13 @@ Global Options
                                 "``.env``" found by searching from the current
                                 directory upwards.
 
+                                **Warning**: Care must be taken when this file
+                                is located in a Git repository so as not to
+                                publicly expose it: either list the file in
+                                ``.gitignore`` or, if using Datalad or
+                                git-annex, configure git-annex to prohibit
+                                public sharing of the file.
+
 -l LEVEL, --log-level LEVEL     Set the log level to the given value.  Possible
                                 values are "``CRITICAL``", "``ERROR``",
                                 "``WARNING``", "``INFO``", "``DEBUG``" (all

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,12 @@ Global Options
 -c FILE, --config FILE          Read configuration from the given file [default
                                 value: ``config.yml``]
 
+-E FILE, --env FILE             Load environment variables from the given
+                                ``.env`` file.  By default, environment
+                                variables are loaded from the first file named
+                                "``.env``" found by searching from the current
+                                directory upwards.
+
 -l LEVEL, --log-level LEVEL     Set the log level to the given value.  Possible
                                 values are "``CRITICAL``", "``ERROR``",
                                 "``WARNING``", "``INFO``", "``DEBUG``" (all
@@ -325,6 +331,9 @@ Path templates may also contain custom placeholders defined in the top-level
 
 Authentication
 --------------
+
+Note that environment variables can be loaded from a ``.env`` file as an
+alternative to setting them directly in the environment.
 
 GitHub
 ~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,13 +40,14 @@ package_dir =
     =src
 python_requires = ~=3.8
 install_requires =
-    click ~= 7.0
+    click >= 7.0
     click-loglevel ~= 0.2
     datalad ~= 0.14
     in_place ~= 0.4
     pydantic ~= 1.7
     PyGithub ~= 1.55
     python-dateutil ~= 2.7
+    python-dotenv ~= 0.11
     PyYAML ~= 5.0
     requests ~= 2.20
 

--- a/src/tinuous/__main__.py
+++ b/src/tinuous/__main__.py
@@ -22,6 +22,7 @@ import click
 from click_loglevel import LogLevel
 from datalad.api import Dataset
 from dateutil.parser import isoparse
+from dotenv import load_dotenv
 from github import Github
 from github.Repository import Repository
 from github.Workflow import Workflow
@@ -950,6 +951,12 @@ class Config(NoExtraModel):
     show_default=True,
 )
 @click.option(
+    "-E",
+    "--env",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Load environment variables from given .env file",
+)
+@click.option(
     "-l",
     "--log-level",
     type=LogLevel(),
@@ -958,8 +965,9 @@ class Config(NoExtraModel):
     show_default=True,
 )
 @click.pass_context
-def main(ctx: click.Context, config: str, log_level: int) -> None:
+def main(ctx: click.Context, config: str, log_level: int, env: Optional[str]) -> None:
     """ Download build logs from GitHub Actions, Travis, and Appveyor """
+    load_dotenv(env)
     logging.basicConfig(
         format="%(asctime)s [%(levelname)-8s] %(name)s %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%S%z",


### PR DESCRIPTION
I'm tired of having to always export `APPVEYOR_TOKEN` when testing tinuous on the datalad repo.  This PR allows env vars to be set via a *de facto* standard file.