### PR TITLE
Make the "types" setting optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,8 +222,9 @@ keys:
     the given point in time will be retrieved
 
 ``types``
-    *(required)* A list of build trigger event types; only assets for builds
-    triggered by one of the given events will be retrieved
+    A list of build trigger event types; only assets for builds triggered by
+    one of the given events will be retrieved.  If this is not specified,
+    assets will be retrieved for all recognized event types.
 
     The recognized event types are:
 

--- a/src/tinuous/config.py
+++ b/src/tinuous/config.py
@@ -134,7 +134,7 @@ class Config(NoExtraModel):
     ci: CIConfigDict
     since: datetime
     until: Optional[datetime] = None
-    types: List[EventType]
+    types: List[EventType] = Field(default_factory=lambda: list(EventType))
     secrets: Dict[str, Pattern] = Field(default_factory=dict)
     allow_secrets_regex: Optional[Pattern] = Field(None, alias="allow-secrets-regex")
     datalad: DataladConfig = Field(default_factory=DataladConfig)


### PR DESCRIPTION
This PR makes the "types" setting in the config default to all event types if it is not specified.

After this PR is merged, I will remove the "types" setting from `config.yml` in tinuous-inception so that future PRs like #95 will take effect automatically without the need to edit tinuous-inception.