### PR TITLE
[BREAKING] Rename default config file to `tinuous.yaml`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Global Options
 --------------
 
 -c FILE, --config FILE          Read configuration from the given file [default
-                                value: ``config.yml``]
+                                value: ``tinuous.yaml``]
 
 -E FILE, --env FILE             Load environment variables from the given
                                 ``.env`` file.  By default, environment

--- a/src/tinuous/__main__.py
+++ b/src/tinuous/__main__.py
@@ -29,7 +29,7 @@ from .util import log
     "-c",
     "--config",
     type=click.Path(exists=True, dir_okay=False),
-    default="config.yml",
+    default="tinuous.yaml",
     help="Read configuration from the given file",
     show_default=True,
 )


### PR DESCRIPTION
As requested [here](https://github.com/con/tinuous/pull/100#discussion_r650092718).