### PR TITLE
Update GitHub token regex in sample config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -315,7 +315,7 @@ A sample config file:
     since: 2021-01-20T00:00:00Z
     types: [cron, manual, pr, push]
     secrets:
-      github: '\b(v1\.)?[a-f0-9]{40}\b'
+      github: '\bgh[a-z]_[A-Za-z0-9]{36,}\b'
       docker-hub: '\b[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}\b'
       appveyor: '\b(v2\.)?[a-z0-9]{20}\b'
       travis: '\b[a-zA-Z0-9]{22}\b'


### PR DESCRIPTION
The format of GitHub tokens changed back in April.  This PR updates the regex given in the sample config to match, based on  the information [here](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats) and [here](https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/).