### PR TITLE
Save changes in DataLad if only the statefile was modified

### DIFF
--- a/src/tinuous/__main__.py
+++ b/src/tinuous/__main__.py
@@ -146,14 +146,18 @@ def fetch(config_file: str, state_path: Optional[str], sanitize_secrets: bool) -
     log.info("%d logs downloaded", logs_added)
     log.info("%d artifacts downloaded", artifacts_added)
     log.info("%d release assets downloaded", relassets_added)
-    if cfg.datalad.enabled and (logs_added or artifacts_added or relassets_added):
-        msg = f"[tinuous] {logs_added} logs added"
-        if artifacts_added:
-            msg += f", {artifacts_added} artifacts added"
-        if relassets_added:
-            msg += f", {relassets_added} release assets added"
-        msg += f"\n\nProduced by tinuous {__version__}"
-        ds.save(recursive=True, message=msg)
+    if cfg.datalad.enabled:
+        if logs_added or artifacts_added or relassets_added:
+            msg = f"[tinuous] {logs_added} logs added"
+            if artifacts_added:
+                msg += f", {artifacts_added} artifacts added"
+            if relassets_added:
+                msg += f", {relassets_added} release assets added"
+            msg += f"\n\nProduced by tinuous {__version__}"
+            ds.save(recursive=True, message=msg)
+        elif statefile.modified:
+            msg = f"[tinuous] Updated statefile\n\nProduced by tinuous {__version__}"
+            ds.save(recursive=True, message=msg)
 
 
 @main.command("sanitize")

--- a/src/tinuous/state.py
+++ b/src/tinuous/state.py
@@ -20,6 +20,7 @@ class StateFile(BaseModel):
     path: Path
     state: State
     migrating: bool = False
+    modified: bool = False
 
     @classmethod
     def from_file(
@@ -60,6 +61,8 @@ class StateFile(BaseModel):
             return self.default_since
 
     def set_since(self, ciname: str, since: datetime) -> None:
+        if getattr(self.state, ciname) == since:
+            return
         setattr(self.state, ciname, since)
         log.debug("%s timestamp floor updated to %s", ciname, since)
         if self.migrating:
@@ -71,3 +74,4 @@ class StateFile(BaseModel):
             self.migrating = False
         else:
             self.path.write_text(self.state.json())
+        self.modified = True


### PR DESCRIPTION
Also, don't migrate the statefile if there were no changes.

Fixes #119.