### PR TITLE
Escape branch names, workflow names, and Appveyor job envs with percent encoding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -381,9 +381,9 @@ Placeholder             Definition
                         ``cron`` and ``manual``, this is a timestamp for the
                         start of the build; for ``pr``, this is the number of
                         the associated pull request, or ``UNK`` if it cannot be
-                        determined; for ``push``, this is the name of the
-                        branch to which the push was made (or possibly the tag
-                        that was pushed, if using Appveyor) [1]_
+                        determined; for ``push``, this is the escaped [1]_ name
+                        of the branch to which the push was made (or possibly
+                        the tag that was pushed, if using Appveyor) [2]_
 ``{build_commit}``      The hash of the commit the build ran against or that
                         was tagged for the release.  Note that, for PR builds
                         on Travis and Appveyor, this is the hash of an
@@ -395,32 +395,37 @@ Placeholder             Definition
                         (along with PR builds on GitHub Actions), this is
                         always the same as ``{build_commit}``.
 ``{number}``            The run number of the workflow run (GitHub) or the
-                        build number (Travis and Appveyor) [1]_
+                        build number (Travis and Appveyor) [2]_
 ``{status}``            The success status of the workflow run (GitHub) or job
                         (Travis and Appveyor); the exact strings used depend on
-                        the CI system [1]_
+                        the CI system [2]_
 ``{common_status}``     The success status of the workflow run or job,
                         normalized into one of ``success``, ``failed``,
-                        ``errored``, or ``incomplete`` [1]_
-``{wf_name}``           *(GitHub only)* The name of the workflow [1]_
+                        ``errored``, or ``incomplete`` [2]_
+``{wf_name}``           *(GitHub only)* The escaped [1]_ name of the workflow
+                        [2]_
 ``{wf_file}``           *(GitHub only)* The basename of the workflow file
-                        (including the file extension) [1]_
-``{run_id}``            *(GitHub only)* The unique ID of the workflow run [1]_
+                        (including the file extension) [2]_
+``{run_id}``            *(GitHub only)* The unique ID of the workflow run [2]_
 ``{job}``               *(Travis and Appveyor only)* The number of the job,
                         without the build number prefix (Travis) or the job ID
-                        string (Appveyor) [1]_
+                        string (Appveyor) [2]_
 ``{job_index}``         *(Travis and Appveyor only)* The index of the job in
-                        the list returned by the API, starting from 1 [1]_
-``{job_env}``           *(Appveyor only)* The environment variables specific to
-                        the job [1]_
-``{job_env_hash}``      *(Appveyor only)* The SHA1 hash of ``{job_env}`` [1]_
+                        the list returned by the API, starting from 1 [2]_
+``{job_env}``           *(Appveyor only)* The escaped [1]_ environment
+                        variables specific to the job [2]_
+``{job_env_hash}``      *(Appveyor only)* The SHA1 hash of ``{job_env}`` before
+                        escaping [2]_
 ======================  =======================================================
 
 .. _datetime: https://docs.python.org/3/library/datetime.html#datetime-objects
 .. _strftime(): https://docs.python.org/3/library/datetime.html
                 #strftime-and-strptime-format-codes
 
-.. [1] These placeholders are only available for ``path`` and
+.. [1] Escaping consists of percent-encoding the characters ``\/<>:|"?*%`` and
+       replacing each whitespace character with a space.
+
+.. [2] These placeholders are only available for ``path`` and
        ``artifacts_path``, not ``releases_path``
 
 A placeholder's value may be truncated to the first ``n`` characters by writing

--- a/src/tinuous/base.py
+++ b/src/tinuous/base.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field, validator
 import requests
 from requests.exceptions import ChunkedEncodingError
 
-from .util import expand_template, log
+from .util import expand_template, log, sanitize_pathname
 
 COMMON_STATUS_MAP = {
     "success": "success",
@@ -177,7 +177,7 @@ class BuildAsset(ABC, BaseModel):
             "minute": utc_date.strftime("%M"),
             "second": utc_date.strftime("%S"),
             "type": self.event_type.value,
-            "type_id": self.event_id,
+            "type_id": sanitize_pathname(self.event_id),
             "build_commit": self.build_commit,
             "commit": commit,
             "number": str(self.number),

--- a/src/tinuous/util.py
+++ b/src/tinuous/util.py
@@ -141,4 +141,10 @@ def get_github_token() -> str:
 
 
 def sanitize_pathname(s: str) -> str:
-    return re.sub(r'[\x5C/<>:|"?*]', "_", re.sub(r"\s", " ", s))
+    return re.sub(
+        r'[\0\x5C/<>:|"?*%]', lambda m: sanitize_str(m.group()), re.sub(r"\s", " ", s)
+    )
+
+
+def sanitize_str(s: str) -> str:
+    return "".join("%{:02x}".format(b) for b in s.encode("utf-8"))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -8,6 +8,7 @@ from tinuous.util import (
     expand_template,
     parse_slice,
     removeprefix,
+    sanitize_pathname,
 )
 
 
@@ -125,3 +126,22 @@ def test_lazy_slicing_formatter_var_reuse(mocker: MockerFixture) -> None:
 )
 def test_removeprefix(s: str, prefix: str, result: str) -> None:
     assert removeprefix(s, prefix) == result
+
+
+@pytest.mark.parametrize(
+    "s1,s2",
+    [
+        ("\\x20", "%5cx20"),
+        ("foo/bar", "foo%2fbar"),
+        ("<angle>", "%3cangle%3e"),
+        ("foo:bar", "foo%3abar"),
+        ("foo|bar", "foo%7cbar"),
+        ('"foo"', "%22foo%22"),
+        ("foo?", "foo%3f"),
+        ("foo*bar", "foo%2abar"),
+        ("foo%20bar", "foo%2520bar"),
+        ("foo\0bar", "foo%00bar"),
+    ],
+)
+def test_sanitize_pathname(s1: str, s2: str) -> None:
+    assert sanitize_pathname(s1) == s2


### PR DESCRIPTION
Some repos use `/` in their branch names, which tinuous currently uses as-is, creating another directory level.  This PR escapes `/` characters (and other troublesome characters) using percent-encoding, and also adjusts the escaping of workflow names and Appveyor job envs (which currently just replace troublesome characters with underscores) to match.