### PR TITLE
Update codecov action to v2

### DIFF
--- a/.github/workflows/inception-test.yml
+++ b/.github/workflows/inception-test.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: tinuous-inception
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           files: tinuous-inception/coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.toxenv == 'py'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
 


### PR DESCRIPTION
Version 1 of codecov's GitHub action is [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1) and will start experiencing brownouts soon, and they advise updating to v2.