### PR TITLE
Adjust retry parameters for non-Pygithub requests

### DIFF
--- a/src/tinuous/base.py
+++ b/src/tinuous/base.py
@@ -68,7 +68,7 @@ class EventType(Enum):
 
 
 class APIClient:
-    MAX_RETRIES = 10
+    MAX_RETRIES = 12
     ZIPFILE_RETRIES = 5
 
     def __init__(self, base_url: str, headers: Dict[str, str], is_github: bool = False):
@@ -89,8 +89,8 @@ class APIClient:
                 log.warning(
                     "Request to %s returned %d; waiting & retrying", url, r.status_code
                 )
+                sleep(1.25 * 2**i)
                 i += 1
-                sleep(i * i)
             elif (
                 self.is_github
                 and r.status_code == 403


### PR DESCRIPTION
This changes the number of retries and the lengths of inter-retry sleeps to match [the configuration for Pygithub requests](https://github.com/con/tinuous/blob/2fa6a134fd45c278ce2ff8074bf477e51e9bf23b/src/tinuous/github.py#L66-L70).

Closes #147.