### PR TITLE
Test against Python 3.11 and add it to Python setup classifiers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,8 @@ environment:
       TOXENV: py
     - PY: '3.10'
       TOXENV: py
+    - PY: '3.11'
+      TOXENV: py
     - PY: '3.8'
       TOXENV: lint
     - PY: '3.8'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              python-version: ["3.8", "3.9", "3.10"]
+              python-version: ["3.8", "3.9", "3.10", "3.11"]
       - lint
       - typing
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
         toxenv: [py]
         include:
           - python-version: '3.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - '3.8'
   - '3.9'
   - '3.10'
+  - '3.11'
 env:
   - TOXENV=py
 jobs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: MIT License

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,typing,py38,py39,py310
+envlist = lint,typing,py38,py39,py310,py311
 skip_missing_interpreters = True
 isolated_build = True
 minversion = 3.3.0


### PR DESCRIPTION
Python 3.11 came out on October 24, so it's time to start testing against it.