### PR TITLE
Treat GitHub workflows triggered on `pull_request_target` as "pr" events

### DIFF
--- a/src/tinuous/base.py
+++ b/src/tinuous/base.py
@@ -53,6 +53,7 @@ class EventType(Enum):
             "schedule": cls.CRON,
             "push": cls.PUSH,
             "pull_request": cls.PULL_REQUEST,
+            "pull_request_target": cls.PULL_REQUEST,
             "workflow_dispatch": cls.MANUAL,
             "repository_dispatch": cls.MANUAL,
         }.get(gh_event)


### PR DESCRIPTION
Closes #160.