### PR TITLE
Fix codespell version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
           - flake8-unused-arguments
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.4
     hooks:
       - id: codespell
         additional_dependencies:


### PR DESCRIPTION
Installing codespell currently doesn't work because [the repository](https://github.com/codespell-project/codespell) doesn't have a v2.2.5 tag.