### PR TITLE
Test against PyPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - 'pypy-3.8'
+          - 'pypy-3.9'
+          - 'pypy-3.10'
         toxenv: [py]
         include:
           - python-version: '3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,10 @@ commands =
 
 [pytest]
 addopts = --cov=tinuous --no-cov-on-fail
-filterwarnings = error
+filterwarnings =
+    error
+    # <https://github.com/yaml/pyyaml/issues/688>
+    ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
 norecursedirs = test/data
 
 [coverage:run]


### PR DESCRIPTION
`tinuous` has the classifier `Programming Language :: Python :: Implementation :: PyPy` listed in its metadata (likely due to copy & paste), but it doesn't actually test against PyPy.  This PR addresses that.