### PR TITLE
Remove redundant `pragma: no cover` comments

### DIFF
--- a/src/tinuous/base.py
+++ b/src/tinuous/base.py
@@ -202,13 +202,13 @@ class CISystem(ABC, BaseModel):
     @staticmethod
     @abstractmethod
     def get_auth_tokens() -> dict[str, str]:
-        ...  # pragma: no cover
+        ...
 
     @abstractmethod
     def get_build_assets(
         self, event_types: list[EventType], logs: bool, artifacts: bool
     ) -> Iterator[BuildAsset]:
-        ...  # pragma: no cover
+        ...
 
     def register_build(self, ts: datetime, processed: bool) -> None:
         heapq.heappush(self.fetched, (ts, processed))
@@ -268,7 +268,7 @@ class BuildAsset(ABC, BaseModel):
 
     @abstractmethod
     def download(self, path: Path) -> list[Path]:
-        ...  # pragma: no cover
+        ...
 
 
 class BuildLog(BuildAsset):

--- a/src/tinuous/config.py
+++ b/src/tinuous/config.py
@@ -51,7 +51,7 @@ class CIConfig(NoExtraModel, ABC):
     @staticmethod
     @abstractmethod
     def get_auth_tokens() -> dict[str, str]:
-        ...  # pragma: no cover
+        ...
 
     @abstractmethod
     def get_system(
@@ -61,7 +61,7 @@ class CIConfig(NoExtraModel, ABC):
         until: Optional[datetime],
         tokens: dict[str, str],
     ) -> CISystem:
-        ...  # pragma: no cover
+        ...
 
     def gets_builds(self) -> bool:
         return self.paths.gets_builds()


### PR DESCRIPTION
Stub bodies are already configured to be ignored for coverage purposes by [this line](https://github.com/con/tinuous/blob/e0ad333d939ebc7bdd0131684b3bb9606b6c2435/tox.ini#L57).