### PR TITLE
Don't do GitHub CI "push" runs on non-default branches

### DIFF
--- a/.github/workflows/inception-test.yml
+++ b/.github/workflows/inception-test.yml
@@ -3,6 +3,8 @@ name: Test fetching tinuous' logs
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
The "Test fetching tinuous' logs" workflow is currently failing because it ran so much that we exceeded some rate limit.  This can be addressed by not running the workflow on pushes to non-default branches.  Note that it will still run on pushes to PR branches, as that's a separate trigger; we're currently running all tests twice on PRs, with the only difference being that the PR triggers are run on the code as it would be after merging.

I also applied the same change to the normal test workflow for similar reasons.

Note that I included `[skip ci]` in the commit message for this PR, so there will be no workflow runs, as I'm trying not to waste rate limits.