### PR TITLE
Revert "Sanitize ~ in pathname (we do not use/rely on ~ ATM)"

### DIFF
--- a/src/tinuous/util.py
+++ b/src/tinuous/util.py
@@ -133,7 +133,7 @@ def get_github_token() -> str:
 
 def sanitize_pathname(s: str) -> str:
     return re.sub(
-        r'[\0\x5C/<>:|"?*%~]', lambda m: sanitize_str(m.group()), re.sub(r"\s", " ", s)
+        r'[\0\x5C/<>:|"?*%]', lambda m: sanitize_str(m.group()), re.sub(r"\s", " ", s)
     )
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -143,7 +143,6 @@ def test_removeprefix(s: str, prefix: str, result: str) -> None:
         ('"foo"', "%22foo%22"),
         ("foo?", "foo%3f"),
         ("foo*bar", "foo%2abar"),
-        ("foo~bar", "foo%7ebar"),
         ("foo%20bar", "foo%2520bar"),
         ("foo\0bar", "foo%00bar"),
     ],


### PR DESCRIPTION
This reverts commit 1609da8e29451801e17dc77e0a8a61f8679359cb.

It was not the reason and `~` is a legit character so I do not see the need to change behavior ATM.

Continuing on

- https://github.com/con/tinuous/issues/215
- https://github.com/bids-standard/bids-validator/issues/248

will release right away so we do not exist with changed behavior for too long