### PR TITLE
Add GitHub Packages (GHCR) support, downloading images as OCI layouts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,6 +202,19 @@ keys:
                 under which the release's assets will be saved.  If this is not
                 specified, no release assets will be downloaded.
 
+            ``packages``
+                A template string that will be instantiated for each version of
+                each GitHub Package to produce the path for the directory
+                (relative to the current working directory) under which the
+                container image for that version will be saved, in `OCI image
+                layout`_ format.  If this is not specified, no packages will be
+                downloaded.
+
+                Only container packages (i.e. images in the GitHub Container
+                Registry) are supported.  Downloading them requires a GitHub
+                token with the ``read:packages`` scope; the ``GITHUB_TOKEN``
+                that GitHub Actions provides to a workflow does not have it.
+
         ``workflows``
             A specification of the workflows for which to retrieve assets.
             This can be either a list of workflow basenames, including the file
@@ -229,6 +242,48 @@ keys:
 
             When ``workflows`` is not specified, assets are retrieved for all
             workflows in the repository.
+
+        ``packages``
+            A specification of the GitHub Packages for which to retrieve
+            images.  This can be either a list of package names or a mapping
+            containing the following fields:
+
+            ``include``
+                A list of packages to retrieve, given as either names or (when
+                ``regex`` is true) `Python regular expressions`_ to match
+                against package names.  If ``include`` is omitted, it defaults
+                to including all packages.
+
+            ``exclude``
+                A list of packages to not retrieve, given as either names or
+                (when ``regex`` is true) `Python regular expressions`_ to match
+                against package names.  If ``exclude`` is omitted, no packages
+                are excluded.  Packages that match both ``include`` and
+                ``exclude`` are excluded.
+
+            ``regex``
+                A boolean.  If true (default false), the elements of the
+                ``include`` and ``exclude`` fields are treated as `Python
+                regular expressions`_ that are matched (unanchored) against
+                package names; if false, they are used as exact names.
+
+            ``owner_wide``
+                A boolean.  GitHub only lists packages per user or
+                organization, not per repository, and a package need not belong
+                to any repository at all.  By default only those packages that
+                belong to the repository being backed up are retrieved; set
+                this to true (default false) to retrieve every matching package
+                owned by the same user or organization.
+
+            ``untagged``
+                A boolean.  If false (the default), package versions that have
+                no tags are skipped.  These are mostly intermediate ``buildx``
+                manifests, build cache, and attestations rather than images
+                that anyone published, and there tend to be a great many of
+                them.
+
+            When ``packages`` is not specified, images are retrieved for all
+            tagged versions of all of the repository's packages.
 
     ``travis``
         Configuration for retrieving logs from Travis-CI.com.  Subfield:
@@ -392,6 +447,8 @@ keys:
     .. _DataLad: https://www.datalad.org
 
 .. _Python regular expressions: https://docs.python.org/3/library/re.html
+.. _OCI image layout:
+   https://github.com/opencontainers/image-spec/blob/main/image-layout.md
                                 #regular-expression-syntax
 
 A sample config file:
@@ -408,10 +465,13 @@ A sample config file:
           logs: '{build_prefix}/{wf_name}/{number}/logs/'
           artifacts: '{build_prefix}/{wf_name}/{number}/artifacts/'
           releases: '{path_prefix}/{release_tag}/'
+          packages: '{path_prefix}/packages/{package_name}/{digest}/'
         workflows:
           - test_crippled.yml
           - test_extensions.yml
           - test_macos.yml
+        packages:
+          - tinuous-inception
       travis:
         paths:
           logs: '{build_prefix}/{number}/{job}.txt'
@@ -436,6 +496,36 @@ A sample config file:
     datalad:
       enabled: true
       cfg_proc: text2git
+
+
+GitHub Packages
+---------------
+
+Each version of a container package is saved as an `OCI image layout`_
+directory, which ``podman`` and ``skopeo`` read directly::
+
+    $ podman run oci:2026/08/github/packages/tinuous-inception/sha256%3a530a02.../
+    Built at: 2026-01-06 20:30:58 UTC
+
+    $ skopeo copy oci:<path> docker://ghcr.io/con/tinuous-inception:restored
+
+The directory holds the standard ``oci-layout`` and ``index.json`` files and a
+``blobs/`` tree containing the manifest, the config, and every layer, plus a
+``package.json`` written by tinuous recording the package name, the version ID,
+its tags, and the image reference it came from.  Manifests are stored exactly
+as the registry served them, so the archived digests are the upstream digests
+and can be checked against them.
+
+``index.json`` is written only once every blob is present, so an interrupted
+download leaves behind a directory that is not mistaken for a complete image
+and is resumed on the next run.  Images are fetched by digest rather than by
+tag, and a version already on disk is not downloaded again.
+
+Multi-platform images are saved whole: the image index, every platform's
+manifest, and all of their layers.  Note that a single such image can run to
+several hundred megabytes, and that all versions of a package share most of
+their layers -- if the paths are inside a DataLad dataset, git-annex will store
+each layer once no matter how many versions refer to it.
 
 
 Path Templates
@@ -476,8 +566,8 @@ Placeholder             Definition
 ``{ci}``                The name of the CI system (``github``, ``travis``,
                         ``appveyor``, or ``circleci``)
 ``{type}``              The event type that triggered the build (``cron``,
-                        ``manual``, ``pr``, or ``push``), or ``release`` for
-                        GitHub releases
+                        ``manual``, ``pr``, or ``push``), ``release`` for
+                        GitHub releases, or ``package`` for GitHub Packages
 ``{type_id}``           Further information on the triggering event; for
                         ``cron`` and ``manual``, this is a timestamp for the
                         start of the build; for ``pr``, this is the number of
@@ -528,6 +618,18 @@ Placeholder             Definition
 ``{step_name}``         *(CircleCI only)* The escaped [1]_ name of the step [2]_
 ``{index}``             *(CircleCI only)* The index of the parallel container
                         that the step ran on [2]_
+``{package_name}``      The escaped [1]_ name of the package [3]_
+``{package_type}``      The type of the package (always ``container``) [3]_
+``{version_id}``        The unique ID of the package version [3]_
+``{digest}``            The escaped [1]_ digest of the package version's
+                        manifest, e.g. ``sha256%3a26af75a3...`` [3]_
+``{tag}``               The escaped [1]_ first tag of the package version, or
+                        ``{digest}`` if it has none.  Note that a tag such as
+                        ``latest`` moves from one version to the next, so a
+                        path keyed on it holds only the most recent version to
+                        have carried it [3]_
+``{tags}``              A comma-separated list of the escaped [1]_ tags of the
+                        package version [3]_
 ======================  =======================================================
 
 .. _datetime: https://docs.python.org/3/library/datetime.html#datetime-objects
@@ -538,7 +640,9 @@ Placeholder             Definition
        replacing each whitespace character with a space.
 
 .. [2] These placeholders are only available for ``path`` and
-       ``artifacts_path``, not ``releases_path``
+       ``artifacts_path``, not ``releases_path`` or ``packages``
+
+.. [3] These placeholders are only available for ``packages``
 
 A placeholder's value may be truncated to the first ``n`` characters by writing
 ``{placeholder[:n]}``, e.g., ``{commit[:7]}``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     click-loglevel ~= 0.2
     ghtoken ~= 0.1
     in_place ~= 1.0
+    oras ~= 0.2
     pydantic ~= 2.0
     python-dateutil ~= 2.7
     python-dotenv >= 0.11, < 2.0
@@ -83,6 +84,9 @@ pretty = True
 plugins = pydantic.mypy
 
 [mypy-datalad.*]
+ignore_missing_imports = True
+
+[mypy-oras.*]
 ignore_missing_imports = True
 
 [pydantic-mypy]

--- a/src/tinuous/__main__.py
+++ b/src/tinuous/__main__.py
@@ -180,8 +180,13 @@ def fetch(
     logs_added = 0
     artifacts_added = 0
     relassets_added = 0
+    packages_added = 0
     for name, cicfg in cfg.ci.items():
-        if not cicfg.gets_builds() and not cicfg.gets_releases():
+        if (
+            not cicfg.gets_builds()
+            and not cicfg.gets_releases()
+            and not cicfg.gets_packages()
+        ):
             log.info("No paths configured for %s; skipping", name)
             continue
         log.info("Fetching resources from %s", name)
@@ -228,17 +233,31 @@ def fetch(
                     ensure_datalad(ds, path, cfg.datalad.cfg_proc)
                 paths = asset.download(Path(path))
                 relassets_added += len(paths)
+        if cicfg.gets_packages():
+            assert isinstance(ci, GitHubActions)
+            assert isinstance(cicfg.paths, GHPathsDict)
+            packages_path = cicfg.paths.packages
+            assert packages_path is not None
+            for pkgasset in ci.get_package_assets():
+                path = pkgasset.expand_path(packages_path, cfg.vars)
+                if cfg.datalad.enabled:
+                    ensure_datalad(ds, path, cfg.datalad.cfg_proc)
+                if pkgasset.download(Path(path)):
+                    packages_added += 1
         statefile.set_since(name, ci.new_since())
     log.info("%d logs downloaded", logs_added)
     log.info("%d artifacts downloaded", artifacts_added)
     log.info("%d release assets downloaded", relassets_added)
+    log.info("%d package versions downloaded", packages_added)
     if cfg.datalad.enabled:
-        if logs_added or artifacts_added or relassets_added:
+        if logs_added or artifacts_added or relassets_added or packages_added:
             msg = f"[tinuous] {logs_added} logs added"
             if artifacts_added:
                 msg += f", {artifacts_added} artifacts added"
             if relassets_added:
                 msg += f", {relassets_added} release assets added"
+            if packages_added:
+                msg += f", {packages_added} package versions added"
             msg += f"\n\nProduced by tinuous {__version__}"
             ds.save(recursive=True, message=msg)
         elif statefile.modified:

--- a/src/tinuous/base.py
+++ b/src/tinuous/base.py
@@ -327,3 +327,21 @@ class WorkflowSpec(NoExtraModel):
 class GHWorkflowSpec(WorkflowSpec):
     def match(self, wf_path: str) -> bool:
         return super().match(PurePosixPath(wf_path).name)
+
+
+class PackageSpec(WorkflowSpec):
+    """
+    Which GitHub Packages to fetch.  `include`/`exclude`/`regex` are matched
+    against package names exactly as for workflows.
+    """
+
+    #: The GitHub API only lists packages per owner, not per repository.  By
+    #: default only those belonging to the configured repository are fetched;
+    #: set this to true to fetch every matching package owned by the same user
+    #: or organization.
+    owner_wide: bool = False
+
+    #: Whether to fetch package versions that have no tags.  These are mostly
+    #: intermediate `buildx` manifests and build attestations rather than
+    #: images anyone published, and there tend to be a great many of them.
+    untagged: bool = False

--- a/src/tinuous/config.py
+++ b/src/tinuous/config.py
@@ -9,7 +9,14 @@ from typing import Any, Dict, List, Optional, Pattern
 from pydantic import Field, field_validator
 
 from .appveyor import Appveyor
-from .base import CISystem, EventType, GHWorkflowSpec, NoExtraModel, WorkflowSpec
+from .base import (
+    CISystem,
+    EventType,
+    GHWorkflowSpec,
+    NoExtraModel,
+    PackageSpec,
+    WorkflowSpec,
+)
 from .circleci import CircleCI
 from .github import GitHubActions
 from .travis import Travis
@@ -25,10 +32,14 @@ class PathsDict(NoExtraModel):
     def gets_releases(self) -> bool:
         return False
 
+    def gets_packages(self) -> bool:
+        return False
+
 
 class GHPathsDict(PathsDict):
     artifacts: Optional[str] = None
     releases: Optional[str] = None
+    packages: Optional[str] = None
 
     def gets_builds(self) -> bool:
         # <https://github.com/pydantic/pydantic/issues/8052>
@@ -36,6 +47,9 @@ class GHPathsDict(PathsDict):
 
     def gets_releases(self) -> bool:
         return self.releases is not None
+
+    def gets_packages(self) -> bool:
+        return self.packages is not None
 
 
 class CCIPathsDict(PathsDict):
@@ -70,14 +84,26 @@ class CIConfig(NoExtraModel, ABC):
     def gets_releases(self) -> bool:
         return self.paths.gets_releases()
 
+    def gets_packages(self) -> bool:
+        return self.paths.gets_packages()
+
 
 class GitHubConfig(CIConfig):
     paths: GHPathsDict = Field(default_factory=GHPathsDict)
     workflows: GHWorkflowSpec = Field(default_factory=GHWorkflowSpec)
+    packages: PackageSpec = Field(default_factory=PackageSpec)
 
     @field_validator("workflows", mode="before")
     @classmethod
     def _workflow_list(cls, v: Any) -> Any:
+        if isinstance(v, list):
+            return {"include": v}
+        else:
+            return v
+
+    @field_validator("packages", mode="before")
+    @classmethod
+    def _package_list(cls, v: Any) -> Any:
         if isinstance(v, list):
             return {"include": v}
         else:
@@ -100,6 +126,7 @@ class GitHubConfig(CIConfig):
             until=until,
             token=tokens["github"],
             workflow_spec=self.workflows,
+            package_spec=self.packages,
         )
 
 

--- a/src/tinuous/ghcr.py
+++ b/src/tinuous/ghcr.py
@@ -65,9 +65,12 @@ class DigestMismatch(Exception):
     """Raised when downloaded content does not hash to its expected digest"""
 
     def __init__(self, expected: str, actual: str) -> None:
-        super().__init__(f"Expected content with digest {expected}, got {actual}")
+        super().__init__(expected, actual)
         self.expected = expected
         self.actual = actual
+
+    def __str__(self) -> str:
+        return f"Expected content with digest {self.expected}, got {self.actual}"
 
 
 def get_registry(

--- a/src/tinuous/ghcr.py
+++ b/src/tinuous/ghcr.py
@@ -1,0 +1,280 @@
+"""
+Downloading container images from a registry into an OCI image layout.
+
+The heavy lifting -- parsing image references, the ``WWW-Authenticate`` token
+dance, and credential handling -- is done by `oras-py`_, the Python SDK of the
+`ORAS`_ project.  What is left, and what lives here, is walking a manifest and
+writing the blobs out in the `OCI Image Layout`_ format that ``podman`` and
+``skopeo`` consume.
+
+.. _oras-py: https://github.com/oras-project/oras-py
+.. _ORAS: https://oras.land
+.. _OCI Image Layout:
+   https://github.com/opencontainers/image-spec/blob/main/image-layout.md
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import oras.container
+import oras.provider
+
+from .util import log
+
+#: Media types denoting a single image manifest.  GHCR serves the ``docker``
+#: spelling for anything pushed by ``docker buildx``, which in practice is most
+#: of what is in there, so both spellings have to be accepted.
+MANIFEST_MEDIA_TYPES = frozenset(
+    [
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ]
+)
+
+#: Media types denoting an image index (a.k.a. a "manifest list"), used for
+#: multi-platform images.
+INDEX_MEDIA_TYPES = frozenset(
+    [
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+    ]
+)
+
+ACCEPT_MANIFEST = ", ".join(sorted(MANIFEST_MEDIA_TYPES | INDEX_MEDIA_TYPES))
+
+OCI_LAYOUT_VERSION = "1.0.0"
+
+GHCR_HOSTNAME = "ghcr.io"
+
+REF_NAME_ANNOTATION = "org.opencontainers.image.ref.name"
+
+#: `oras` reads credentials for a registry out of `~/.docker/config.json` and
+#: friends; tinuous passes the GitHub token in explicitly instead, so tell it
+#: not to go looking.  Any username works for GHCR as long as the password is a
+#: token with `read:packages`.
+GHCR_USERNAME = "tinuous"
+
+
+class DigestMismatch(Exception):
+    """Raised when downloaded content does not hash to its expected digest"""
+
+    def __init__(self, expected: str, actual: str) -> None:
+        super().__init__(f"Expected content with digest {expected}, got {actual}")
+        self.expected = expected
+        self.actual = actual
+
+
+def get_registry(
+    hostname: str, token: Optional[str] = None, insecure: bool = False
+) -> oras.provider.Registry:
+    """
+    Construct an `oras` registry client for ``hostname``, authenticating with
+    ``token`` if given and anonymously otherwise.
+    """
+    registry = oras.provider.Registry(hostname=hostname, insecure=insecure)
+    if token is not None:
+        # `oras` exchanges these for a registry bearer token on the first 401,
+        # which is the only form GHCR accepts; a GitHub token presented
+        # directly as a bearer is rejected.
+        registry.auth.set_basic_auth(GHCR_USERNAME, token)
+    return registry
+
+
+def digest_path(layout: Path, digest: str) -> Path:
+    algorithm, _, encoded = digest.partition(":")
+    if not algorithm or not encoded or "/" in encoded or encoded.startswith("."):
+        raise ValueError(f"Malformed digest: {digest!r}")
+    return layout / "blobs" / algorithm / encoded
+
+
+@contextmanager
+def staged_blob(layout: Path, digest: str) -> Iterator[Path]:
+    """
+    Context manager yielding a temporary path to write the blob for ``digest``
+    to.  On a clean exit the content is checked against ``digest`` and moved
+    into place; otherwise the partial file is removed.  Leaving a partial blob
+    behind would be worse than not downloading it at all, as every later run
+    would take it for a complete one.
+    """
+    target = digest_path(layout, digest)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(target.name + ".tmp")
+    try:
+        yield tmp
+        actual = f"{digest.partition(':')[0]}:{hash_file(tmp, digest)}"
+        if actual != digest:
+            raise DigestMismatch(digest, actual)
+        tmp.replace(target)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def hash_file(path: Path, digest: str) -> str:
+    h = hashlib.new(digest.partition(":")[0])
+    with path.open("rb") as fp:
+        while chunk := fp.read(65536):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+class OCILayout:
+    """An OCI image layout directory being assembled on disk"""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def has_blob(self, digest: str) -> bool:
+        return digest_path(self.path, digest).exists()
+
+    def write_blob(self, digest: str, content: bytes) -> None:
+        if self.has_blob(digest):
+            return
+        with staged_blob(self.path, digest) as tmp:
+            tmp.write_bytes(content)
+
+    def fetch_blob(
+        self,
+        registry: oras.provider.Registry,
+        container: oras.container.Container,
+        digest: str,
+    ) -> None:
+        if self.has_blob(digest):
+            log.debug("Blob %s already present; not downloading", digest)
+            return
+        log.debug("Downloading blob %s", digest)
+        with staged_blob(self.path, digest) as tmp:
+            with registry.get_blob(container, digest, stream=True) as r:
+                r.raise_for_status()
+                with tmp.open("wb") as fp:
+                    for chunk in r.iter_content(chunk_size=65536):
+                        fp.write(chunk)
+
+    def fetch_manifest(
+        self,
+        registry: oras.provider.Registry,
+        container: oras.container.Container,
+        reference: str,
+    ) -> tuple[str, bytes]:
+        """
+        Fetch the manifest for ``reference`` (a tag or a digest), returning its
+        digest and its bytes *as served*.  Reserializing the JSON would change
+        the digest and thus produce an archive that cannot be checked against
+        the registry it came from.
+        """
+        url = (
+            f"{registry.prefix}://{container.registry}"
+            f"/v2/{container.api_prefix}/manifests/{reference}"
+        )
+        r = registry.do_request(url, "GET", headers={"Accept": ACCEPT_MANIFEST})
+        r.raise_for_status()
+        content = r.content
+        digest = r.headers.get("Docker-Content-Digest")
+        if digest is None:
+            return "sha256:" + hashlib.sha256(content).hexdigest(), content
+        algorithm = digest.partition(":")[0]
+        computed = f"{algorithm}:{hashlib.new(algorithm, content).hexdigest()}"
+        if digest != computed:
+            raise DigestMismatch(digest, computed)
+        return digest, content
+
+    def fetch_recursively(
+        self,
+        registry: oras.provider.Registry,
+        container: oras.container.Container,
+        reference: str,
+    ) -> tuple[str, str]:
+        """
+        Fetch the manifest for ``reference`` and everything it references,
+        storing it all as blobs.  Returns the manifest's digest and media type.
+        """
+        digest, content = self.fetch_manifest(registry, container, reference)
+        manifest = json.loads(content)
+        media_type = manifest.get("mediaType", "")
+        if media_type in INDEX_MEDIA_TYPES:
+            for entry in manifest.get("manifests", []):
+                # A manifest blob is written only once everything below it is,
+                # so one that is already present has a complete subtree.
+                if not self.has_blob(entry["digest"]):
+                    # Sub-manifests have to be fetched from the manifest
+                    # endpoint; a registry will not serve them as blobs.
+                    self.fetch_recursively(registry, container, entry["digest"])
+        elif media_type in MANIFEST_MEDIA_TYPES:
+            entries = list(manifest.get("layers", []))
+            if "config" in manifest:
+                entries.append(manifest["config"])
+            for entry in entries:
+                self.fetch_blob(registry, container, entry["digest"])
+        else:
+            raise ValueError(f"Unsupported manifest media type: {media_type!r}")
+        self.write_blob(digest, content)
+        return digest, media_type
+
+    def write_index(
+        self, digest: str, media_type: str, size: int, tag: Optional[str] = None
+    ) -> None:
+        """
+        Write ``oci-layout`` and ``index.json``, which together make the
+        directory a layout that ``podman`` and ``skopeo`` will read.  This is
+        done last, so that an interrupted download leaves behind a directory
+        that is not mistaken for a complete image.
+        """
+        entry: dict[str, Any] = {
+            "mediaType": media_type,
+            "digest": digest,
+            "size": size,
+        }
+        if tag is not None:
+            entry["annotations"] = {REF_NAME_ANNOTATION: tag}
+        (self.path / "oci-layout").write_text(
+            json.dumps({"imageLayoutVersion": OCI_LAYOUT_VERSION}) + "\n"
+        )
+        (self.path / "index.json").write_text(
+            json.dumps({"schemaVersion": 2, "manifests": [entry]}, indent=2) + "\n"
+        )
+
+    def is_complete(self) -> bool:
+        return (self.path / "index.json").exists()
+
+    def index_digest(self) -> Optional[str]:
+        """The digest recorded in ``index.json``, or `None` if there is none"""
+        try:
+            with (self.path / "index.json").open() as fp:
+                index = json.load(fp)
+            digest = index["manifests"][0]["digest"]
+        except (OSError, ValueError, LookupError):
+            return None
+        assert isinstance(digest, str)
+        return digest
+
+    def iterfiles(self) -> Iterator[Path]:
+        for p in sorted(self.path.rglob("*")):
+            if p.is_file():
+                yield p
+
+
+def download_image(
+    registry: oras.provider.Registry,
+    image: str,
+    path: Path,
+    tag: Optional[str] = None,
+) -> str:
+    """
+    Download ``image`` (e.g. ``ghcr.io/con/tinuous-inception:latest`` or
+    ``...@sha256:...``) into an OCI image layout at ``path``, and return the
+    digest of its manifest.
+    """
+    container = registry.get_container(image)
+    reference = container.digest or container.tag
+    path.mkdir(parents=True, exist_ok=True)
+    layout = OCILayout(path)
+    digest, media_type = layout.fetch_recursively(registry, container, reference)
+    size = digest_path(path, digest).stat().st_size
+    layout.write_index(digest, media_type, size, tag)
+    return digest

--- a/src/tinuous/github.py
+++ b/src/tinuous/github.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from functools import cached_property
+import json
 from pathlib import Path
 import re
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
+from oras.provider import Registry
 from pydantic import BaseModel, Field
 import requests
 
@@ -19,12 +21,15 @@ from .base import (
     CISystem,
     EventType,
     GHWorkflowSpec,
+    PackageSpec,
 )
+from .ghcr import GHCR_HOSTNAME, OCILayout, download_image, get_registry
 from .util import expand_template, get_github_token, iterfiles, log, sanitize_pathname
 
 
 class GitHubActions(CISystem):
     workflow_spec: GHWorkflowSpec
+    package_spec: PackageSpec = Field(default_factory=PackageSpec)
     hash2pr: Dict[str, str] = Field(default_factory=dict)
 
     @staticmethod
@@ -264,6 +269,95 @@ class GitHubActions(CISystem):
                     download_url=asset.browser_download_url,
                 )
 
+    @cached_property
+    def registry(self) -> Registry:
+        return get_registry(GHCR_HOSTNAME, self.token)
+
+    def get_packages(self) -> Iterator[Package]:
+        """
+        List the owner's container packages.  GitHub only exposes packages per
+        owner, so unless ``owner_wide`` is set, those belonging to other
+        repositories are filtered out here.
+        """
+        owner = self.repo.partition("/")[0]
+        params = {"package_type": "container"}
+        # An organization and a user are different endpoints, and there is no
+        # way to tell which one an owner is without asking.
+        for endpoint in [f"/orgs/{owner}/packages", f"/users/{owner}/packages"]:
+            try:
+                packages = list(self.paginate(endpoint, params=params))
+            except requests.HTTPError as e:
+                if e.response is not None and e.response.status_code == 404:
+                    continue
+                if e.response is not None and e.response.status_code == 403:
+                    raise RuntimeError(
+                        f"Access to {endpoint} was denied; a token with the"
+                        " 'read:packages' scope is needed in order to fetch"
+                        " GitHub Packages"
+                    ) from e
+                raise
+            for item in packages:
+                pkg = Package.model_validate(item)
+                if not self.package_spec.owner_wide and pkg.repo_name != self.repo:
+                    log.debug(
+                        "Package %s belongs to %s, not %s; skipping",
+                        pkg.name,
+                        pkg.repo_name,
+                        self.repo,
+                    )
+                    continue
+                yield pkg
+            return
+        log.info("No packages found for %s", owner)
+
+    def get_package_versions(self, package: Package) -> Iterator[PackageVersion]:
+        # The package name goes in a path segment and can itself contain
+        # slashes (e.g. "example-notebooks/000409-ibl"), so it has to be
+        # encoded.
+        name = quote(package.name, safe="")
+        endpoint = f"{package.owner_endpoint}/packages/container/{name}/versions"
+        for item in self.paginate(endpoint):
+            yield PackageVersion.model_validate(item)
+
+    def get_package_assets(self) -> Iterator[GHPackageAsset]:
+        log.info("Fetching package versions newer than %s", self.since)
+        if self.until is not None:
+            log.info("Skipping package versions newer than %s", self.until)
+        for pkg in self.get_packages():
+            if not self.package_spec.match(pkg.name):
+                log.debug("Package %s excluded by config; skipping", pkg.name)
+                continue
+            log.info("Found package %s", pkg.name)
+            for version in self.get_package_versions(pkg):
+                ts = version.updated_at
+                if ts <= self.since or (self.until is not None and ts > self.until):
+                    continue
+                if not version.tags and not self.package_spec.untagged:
+                    log.debug(
+                        "Version %s of package %s is untagged; skipping",
+                        version.name,
+                        pkg.name,
+                    )
+                    continue
+                self.register_build(ts, True)
+                log.info(
+                    "Found version %s of package %s (tags: %s)",
+                    version.name,
+                    pkg.name,
+                    ", ".join(version.tags) if version.tags else "<none>",
+                )
+                yield GHPackageAsset(
+                    registry=self.registry,
+                    owner=pkg.owner,
+                    package_name=pkg.name,
+                    package_type=pkg.package_type,
+                    version_id=version.id,
+                    digest=version.name,
+                    tags=version.tags,
+                    updated_at=ts,
+                    html_url=version.html_url,
+                )
+
 
 class GHAAsset(BuildAsset):
     workflow_name: str
@@ -497,3 +591,152 @@ class Release(BaseModel):
     created_at: datetime
     published_at: Optional[datetime] = None
     assets: List[ReleaseAsset]
+
+
+class PackageRepository(BaseModel):
+    full_name: str
+
+
+class Package(BaseModel):
+    id: int
+    name: str
+    package_type: str
+    created_at: datetime
+    updated_at: datetime
+    url: str
+    repository: Optional[PackageRepository] = None
+
+    @property
+    def repo_name(self) -> Optional[str]:
+        """The ``owner/name`` of the repository the package is linked to"""
+        return self.repository.full_name if self.repository is not None else None
+
+    @property
+    def owner_endpoint(self) -> str:
+        """
+        The ``/orgs/{owner}`` or ``/users/{owner}`` prefix under which this
+        package is served, taken from the URL the API itself reported.
+        """
+        m = re.search(r"/(?:orgs|users)/[^/]+", self.url)
+        if m is None:
+            raise ValueError(f"Cannot determine owner endpoint from {self.url!r}")
+        return m.group()
+
+    @property
+    def owner(self) -> str:
+        return self.owner_endpoint.rpartition("/")[2]
+
+
+class ContainerMetadata(BaseModel):
+    tags: List[str] = Field(default_factory=list)
+
+
+class PackageVersionMetadata(BaseModel):
+    package_type: str
+    container: Optional[ContainerMetadata] = None
+
+
+class PackageVersion(BaseModel):
+    id: int
+    #: For container packages this is the manifest digest, not a tag
+    name: str
+    url: str
+    created_at: datetime
+    updated_at: datetime
+    html_url: Optional[str] = None
+    metadata: Optional[PackageVersionMetadata] = None
+
+    @property
+    def tags(self) -> List[str]:
+        if self.metadata is None or self.metadata.container is None:
+            return []
+        return self.metadata.container.tags
+
+
+# The `arbitrary_types_allowed` is for Registry
+class GHPackageAsset(BaseModel, arbitrary_types_allowed=True):
+    registry: Registry
+    owner: str
+    package_name: str
+    package_type: str
+    version_id: int
+    digest: str
+    tags: List[str]
+    updated_at: datetime
+    html_url: Optional[str] = None
+
+    @property
+    def image(self) -> str:
+        """
+        The image to pull, referenced by digest.  Tags move, and one could move
+        between listing the version and downloading it; the digest is what the
+        version actually is.
+        """
+        return f"{self.registry.hostname}/{self.owner}/{self.package_name}@{self.digest}"
+
+    @property
+    def tag(self) -> Optional[str]:
+        return self.tags[0] if self.tags else None
+
+    def path_fields(self) -> dict[str, Any]:
+        utc_date = self.updated_at.astimezone(timezone.utc)
+        return {
+            "timestamp": utc_date,
+            "timestamp_local": self.updated_at.astimezone(),
+            "year": utc_date.strftime("%Y"),
+            "month": utc_date.strftime("%m"),
+            "day": utc_date.strftime("%d"),
+            "hour": utc_date.strftime("%H"),
+            "minute": utc_date.strftime("%M"),
+            "second": utc_date.strftime("%S"),
+            "ci": "github",
+            "type": "package",
+            "package_name": sanitize_pathname(self.package_name),
+            "package_type": self.package_type,
+            "version_id": str(self.version_id),
+            "digest": sanitize_pathname(self.digest),
+            "tag": sanitize_pathname(self.tag if self.tag is not None else self.digest),
+            "tags": ",".join(sanitize_pathname(t) for t in self.tags),
+        }
+
+    def expand_path(self, path_template: str, variables: dict[str, str]) -> str:
+        return expand_template(path_template, self.path_fields(), variables)
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "package_name": self.package_name,
+            "package_type": self.package_type,
+            "version_id": self.version_id,
+            "digest": self.digest,
+            "tags": self.tags,
+            "updated_at": self.updated_at.isoformat(),
+            "image": self.image,
+            "html_url": self.html_url,
+        }
+
+    def download(self, path: Path) -> list[Path]:
+        layout = OCILayout(path)
+        if layout.is_complete():
+            if layout.index_digest() == self.digest:
+                log.info(
+                    "Version %s of package %s already downloaded to %s; skipping",
+                    self.digest,
+                    self.package_name,
+                    path,
+                )
+                return []
+            # This happens when the path template is keyed on something mutable
+            # like `{tag}` and the tag has since been moved to a new version.
+            log.info(
+                "%s holds a different version of package %s; replacing it with %s",
+                path,
+                self.package_name,
+                self.digest,
+            )
+        log.info("Downloading %s to %s", self.image, path)
+        path.mkdir(parents=True, exist_ok=True)
+        download_image(self.registry, self.image, path, tag=self.tag)
+        with (path / "package.json").open("w", encoding="utf-8") as fp:
+            json.dump(self.metadata(), fp, indent=2)
+            print(file=fp)
+        return list(layout.iterfiles())

--- a/src/tinuous/github.py
+++ b/src/tinuous/github.py
@@ -672,7 +672,10 @@ class GHPackageAsset(BaseModel, arbitrary_types_allowed=True):
         between listing the version and downloading it; the digest is what the
         version actually is.
         """
-        return f"{self.registry.hostname}/{self.owner}/{self.package_name}@{self.digest}"
+        return (
+            f"{self.registry.hostname}/{self.owner}"
+            f"/{self.package_name}@{self.digest}"
+        )
 
     @property
     def tag(self) -> Optional[str]:

--- a/test/fake_registry.py
+++ b/test/fake_registry.py
@@ -35,7 +35,17 @@ OCI_INDEX = "application/vnd.oci.image.index.v1+json"
 OCI_CONFIG = "application/vnd.oci.image.config.v1+json"
 OCI_LAYER = "application/vnd.oci.image.layer.v1.tar+gzip"
 
-BUSYBOX = Path("/bin/busybox")
+#: A static shell makes the test images actually runnable, which is what the
+#: podman tests need.  Everything else only cares about the bytes, so the
+#: layers fall back to a plain file when there is no busybox to be had.
+BUSYBOX = next(
+    (
+        Path(p)
+        for p in ["/bin/busybox", "/usr/bin/busybox", shutil.which("busybox") or ""]
+        if p and Path(p).is_file()
+    ),
+    None,
+)
 
 
 def digest_of(data: bytes) -> str:
@@ -55,34 +65,39 @@ def canonical(obj: Any) -> bytes:
     return json.dumps(obj, indent=3).encode("utf-8")
 
 
-def make_layer(message: str) -> tuple[bytes, str]:
+def add_file(tf: tarfile.TarFile, name: str, content: bytes, mode: int) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(content)
+    info.mode = mode
+    tf.addfile(info, io.BytesIO(content))
+
+
+def make_layer(message: str, runnable: bool = False) -> tuple[bytes, str]:
     """
-    Build a gzipped layer tarball holding a static busybox and a script that
-    prints ``message``.  Returns the compressed bytes and the uncompressed
-    digest (the "diff id" that goes into the image config).
+    Build a gzipped layer tarball whose entrypoint prints ``message``.  Returns
+    the compressed bytes and the uncompressed digest (the "diff id" that goes
+    into the image config).
+
+    With ``runnable``, a static busybox is included so that a container runtime
+    can actually execute it; without, the layer is just enough bytes to be a
+    layer.
     """
     raw = io.BytesIO()
     with tarfile.open(fileobj=raw, mode="w") as tf:
-        for name in ("bin", "usr", "usr/bin"):
+        for name in ("bin",):
             info = tarfile.TarInfo(name)
             info.type = tarfile.DIRTYPE
             info.mode = 0o755
             tf.addfile(info)
-        payload = BUSYBOX.read_bytes()
-        info = tarfile.TarInfo("bin/busybox")
-        info.size = len(payload)
-        info.mode = 0o755
-        tf.addfile(info, io.BytesIO(payload))
-        for applet in ("bin/sh", "bin/echo"):
-            link = tarfile.TarInfo(applet)
-            link.type = tarfile.SYMTYPE
-            link.linkname = "/bin/busybox"
-            tf.addfile(link)
-        script = f"#!/bin/sh\necho '{message}'\n".encode()
-        info = tarfile.TarInfo("hello.sh")
-        info.size = len(script)
-        info.mode = 0o755
-        tf.addfile(info, io.BytesIO(script))
+        if runnable:
+            assert BUSYBOX is not None
+            add_file(tf, "bin/busybox", BUSYBOX.read_bytes(), 0o755)
+            for applet in ("bin/sh", "bin/echo"):
+                link = tarfile.TarInfo(applet)
+                link.type = tarfile.SYMTYPE
+                link.linkname = "/bin/busybox"
+                tf.addfile(link)
+        add_file(tf, "hello.sh", f"#!/bin/sh\necho '{message}'\n".encode(), 0o755)
     uncompressed = raw.getvalue()
     compressed = gzip.compress(uncompressed, mtime=0)
     return compressed, digest_of(uncompressed)
@@ -103,9 +118,14 @@ class Image:
         return desc
 
     def add_manifest(
-        self, message: str, architecture: str, *, oci: bool = False
+        self,
+        message: str,
+        architecture: str,
+        *,
+        oci: bool = False,
+        runnable: bool = False,
     ) -> dict[str, Any]:
-        layer, diff_id = make_layer(message)
+        layer, diff_id = make_layer(message, runnable=runnable)
         layer_desc = self.add(OCI_LAYER if oci else DOCKER_LAYER, layer)
         config = canonical(
             {
@@ -140,17 +160,24 @@ class Image:
         self.tags[name] = digest
 
 
-def build_images(architecture: str = "amd64") -> dict[str, Image]:
+def build_images(
+    architecture: str = "amd64", runnable: bool = False
+) -> dict[str, Image]:
     """
     Two images: a single-platform one (as `docker push` produces) and a
     multi-platform one (as `docker buildx --platform` produces).  Both use
     Docker media types, which is what GHCR serves in practice.
     """
     single = Image()
-    single.tag("latest", single.add_manifest("Built at: single", architecture)["digest"])
+    single.tag(
+        "latest",
+        single.add_manifest("Built at: single", architecture, runnable=runnable)[
+            "digest"
+        ],
+    )
 
     multi = Image()
-    native = multi.add_manifest("Built at: multi", architecture)
+    native = multi.add_manifest("Built at: multi", architecture, runnable=runnable)
     other = multi.add_manifest("Built at: multi", "s390x")
     index = multi.add_index([native, other])
     multi.tag("latest", index)
@@ -160,7 +187,10 @@ def build_images(architecture: str = "amd64") -> dict[str, Image]:
     # named "example-notebooks/<dandiset>" -- so exercise a nested name too.
     nested = Image()
     nested.tag(
-        "latest", nested.add_manifest("Built at: nested", architecture)["digest"]
+        "latest",
+        nested.add_manifest("Built at: nested", architecture, runnable=runnable)[
+            "digest"
+        ],
     )
     return {
         "testorg/single": single,
@@ -182,7 +212,7 @@ class Handler(BaseHTTPRequestHandler):
     requests: list[str]
     require_auth: bool
 
-    def log_message(self, format: str, *args: Any) -> None:
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
         pass
 
     def _challenge(self, scope: str) -> None:
@@ -295,7 +325,7 @@ class FakeRegistry:
 
 
 def have_busybox() -> bool:
-    return BUSYBOX.is_file()
+    return BUSYBOX is not None
 
 
 def have_podman() -> bool:

--- a/test/fake_registry.py
+++ b/test/fake_registry.py
@@ -1,0 +1,302 @@
+"""
+A minimal, in-process OCI registry serving a real (tiny) container image.
+
+Enough of the `distribution spec`_ is implemented to pull an image: manifests
+by tag or digest, and blobs by digest.  The images are built from
+``/bin/busybox`` when it is available, so that the layouts tinuous produces can
+be handed to ``podman`` and actually run.
+
+.. _distribution spec:
+   https://github.com/opencontainers/distribution-spec/blob/main/spec.md
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+import gzip
+import hashlib
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import io
+import json
+from pathlib import Path
+import shutil
+import tarfile
+import threading
+from typing import Any, Optional
+
+DOCKER_MANIFEST = "application/vnd.docker.distribution.manifest.v2+json"
+DOCKER_INDEX = "application/vnd.docker.distribution.manifest.list.v2+json"
+DOCKER_CONFIG = "application/vnd.docker.container.image.v1+json"
+DOCKER_LAYER = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+
+OCI_MANIFEST = "application/vnd.oci.image.manifest.v1+json"
+OCI_INDEX = "application/vnd.oci.image.index.v1+json"
+OCI_CONFIG = "application/vnd.oci.image.config.v1+json"
+OCI_LAYER = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+BUSYBOX = Path("/bin/busybox")
+
+
+def digest_of(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def descriptor(media_type: str, data: bytes) -> dict[str, Any]:
+    return {"mediaType": media_type, "digest": digest_of(data), "size": len(data)}
+
+
+def canonical(obj: Any) -> bytes:
+    """
+    Serialize a manifest.  Deliberately *not* the most compact spelling: a
+    consumer that reserializes rather than storing what it was served will end
+    up with a different digest, and these tests should catch that.
+    """
+    return json.dumps(obj, indent=3).encode("utf-8")
+
+
+def make_layer(message: str) -> tuple[bytes, str]:
+    """
+    Build a gzipped layer tarball holding a static busybox and a script that
+    prints ``message``.  Returns the compressed bytes and the uncompressed
+    digest (the "diff id" that goes into the image config).
+    """
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tf:
+        for name in ("bin", "usr", "usr/bin"):
+            info = tarfile.TarInfo(name)
+            info.type = tarfile.DIRTYPE
+            info.mode = 0o755
+            tf.addfile(info)
+        payload = BUSYBOX.read_bytes()
+        info = tarfile.TarInfo("bin/busybox")
+        info.size = len(payload)
+        info.mode = 0o755
+        tf.addfile(info, io.BytesIO(payload))
+        for applet in ("bin/sh", "bin/echo"):
+            link = tarfile.TarInfo(applet)
+            link.type = tarfile.SYMTYPE
+            link.linkname = "/bin/busybox"
+            tf.addfile(link)
+        script = f"#!/bin/sh\necho '{message}'\n".encode()
+        info = tarfile.TarInfo("hello.sh")
+        info.size = len(script)
+        info.mode = 0o755
+        tf.addfile(info, io.BytesIO(script))
+    uncompressed = raw.getvalue()
+    compressed = gzip.compress(uncompressed, mtime=0)
+    return compressed, digest_of(uncompressed)
+
+
+@dataclass
+class Image:
+    """An image built into a set of blobs, addressable by tag"""
+
+    blobs: dict[str, bytes] = field(default_factory=dict)
+    tags: dict[str, str] = field(default_factory=dict)
+    media_types: dict[str, str] = field(default_factory=dict)
+
+    def add(self, media_type: str, data: bytes) -> dict[str, Any]:
+        desc = descriptor(media_type, data)
+        self.blobs[desc["digest"]] = data
+        self.media_types[desc["digest"]] = media_type
+        return desc
+
+    def add_manifest(
+        self, message: str, architecture: str, *, oci: bool = False
+    ) -> dict[str, Any]:
+        layer, diff_id = make_layer(message)
+        layer_desc = self.add(OCI_LAYER if oci else DOCKER_LAYER, layer)
+        config = canonical(
+            {
+                "architecture": architecture,
+                "os": "linux",
+                "config": {"Cmd": ["/bin/sh", "/hello.sh"]},
+                "rootfs": {"type": "layers", "diff_ids": [diff_id]},
+            }
+        )
+        config_desc = self.add(OCI_CONFIG if oci else DOCKER_CONFIG, config)
+        media_type = OCI_MANIFEST if oci else DOCKER_MANIFEST
+        manifest = canonical(
+            {
+                "schemaVersion": 2,
+                "mediaType": media_type,
+                "config": config_desc,
+                "layers": [layer_desc],
+            }
+        )
+        desc = self.add(media_type, manifest)
+        desc["platform"] = {"architecture": architecture, "os": "linux"}
+        return desc
+
+    def add_index(self, manifests: list[dict[str, Any]], *, oci: bool = False) -> str:
+        media_type = OCI_INDEX if oci else DOCKER_INDEX
+        index = canonical(
+            {"schemaVersion": 2, "mediaType": media_type, "manifests": manifests}
+        )
+        return str(self.add(media_type, index)["digest"])
+
+    def tag(self, name: str, digest: str) -> None:
+        self.tags[name] = digest
+
+
+def build_images(architecture: str = "amd64") -> dict[str, Image]:
+    """
+    Two images: a single-platform one (as `docker push` produces) and a
+    multi-platform one (as `docker buildx --platform` produces).  Both use
+    Docker media types, which is what GHCR serves in practice.
+    """
+    single = Image()
+    single.tag("latest", single.add_manifest("Built at: single", architecture)["digest"])
+
+    multi = Image()
+    native = multi.add_manifest("Built at: multi", architecture)
+    other = multi.add_manifest("Built at: multi", "s390x")
+    index = multi.add_index([native, other])
+    multi.tag("latest", index)
+    multi.tag("v1", index)
+
+    # GHCR package names can contain slashes -- dandi's containers are all
+    # named "example-notebooks/<dandiset>" -- so exercise a nested name too.
+    nested = Image()
+    nested.tag(
+        "latest", nested.add_manifest("Built at: nested", architecture)["digest"]
+    )
+    return {
+        "testorg/single": single,
+        "testorg/multi": multi,
+        "testorg/notebooks/nested": nested,
+    }
+
+
+#: What a client must present, having exchanged its credentials at /token.
+#: A registry bearer token is not the same thing as the password used to get
+#: it -- presenting a GitHub token directly as a bearer is what GHCR rejects.
+ISSUED_TOKEN = "issued-registry-token"
+
+CREDENTIALS = ("tinuous", "s3cret")
+
+
+class Handler(BaseHTTPRequestHandler):
+    images: dict[str, Image]
+    requests: list[str]
+    require_auth: bool
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+    def _challenge(self, scope: str) -> None:
+        realm = f"http://{self.headers.get('Host')}/token"
+        body = b'{"errors":[{"code":"UNAUTHORIZED"}]}'
+        self.send_response(401)
+        self.send_header(
+            "WWW-Authenticate",
+            f'Bearer realm="{realm}",service="fake",scope="{scope}"',
+        )
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _issue_token(self) -> None:
+        header = self.headers.get("Authorization", "")
+        if header.startswith("Basic "):
+            decoded = base64.b64decode(header[len("Basic ") :]).decode()
+            username, _, password = decoded.partition(":")
+            if (username, password) == CREDENTIALS:
+                body = json.dumps({"token": ISSUED_TOKEN}).encode()
+                return self._send(200, body, "application/json")
+        self._send(403, b'{"errors":[{"code":"DENIED"}]}', "application/json")
+
+    def _authorized(self) -> bool:
+        return self.headers.get("Authorization") == f"Bearer {ISSUED_TOKEN}"
+
+    def _send(self, code: int, body: bytes, media_type: str, digest: str = "") -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", media_type)
+        self.send_header("Content-Length", str(len(body)))
+        if digest:
+            self.send_header("Docker-Content-Digest", digest)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        self.requests.append(self.path)
+        parts = self.path.strip("/").split("/")
+        if self.path.startswith("/token"):
+            return self._issue_token()
+        if self.path == "/v2/":
+            return self._send(200, b"{}", "application/json")
+        if self.require_auth and not self._authorized():
+            name = "/".join(parts[1:-2]) if len(parts) >= 4 else ""
+            return self._challenge(f"repository:{name}:pull")
+        # /v2/<name>/<manifests|blobs>/<reference>, where <name> may itself
+        # contain slashes (e.g. "dandi/example-notebooks/000409-ibl")
+        if len(parts) < 4 or parts[0] != "v2":
+            return self._send(404, b"{}", "application/json")
+        name = "/".join(parts[1:-2])
+        kind, reference = parts[-2], parts[-1]
+        image = self.images.get(name)
+        if image is None:
+            return self._send(404, b'{"errors":[]}', "application/json")
+        if kind == "manifests":
+            digest = image.tags.get(reference, reference)
+        elif kind == "blobs":
+            digest = reference
+        else:
+            return self._send(404, b'{"errors":[]}', "application/json")
+        data = image.blobs.get(digest)
+        if data is None:
+            return self._send(404, b'{"errors":[]}', "application/json")
+        self._send(200, data, image.media_types[digest], digest)
+
+
+class FakeRegistry:
+    """A registry listening on localhost for the duration of a `with` block"""
+
+    def __init__(
+        self,
+        images: Optional[dict[str, Image]] = None,
+        require_auth: bool = False,
+    ) -> None:
+        self.images = build_images() if images is None else images
+        self.requests: list[str] = []
+        self.require_auth = require_auth
+
+    def __enter__(self) -> FakeRegistry:
+        handler = type(
+            "BoundHandler",
+            (Handler,),
+            {
+                "images": self.images,
+                "requests": self.requests,
+                "require_auth": self.require_auth,
+            },
+        )
+        self.server = HTTPServer(("127.0.0.1", 0), handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+    @property
+    def hostname(self) -> str:
+        host, port = self.server.server_address[:2]
+        assert isinstance(host, str)
+        return f"{host}:{port}"
+
+    def image_ref(self, name: str, reference: str = "latest") -> str:
+        sep = "@" if reference.startswith("sha256:") else ":"
+        return f"{self.hostname}/{name}{sep}{reference}"
+
+
+def have_busybox() -> bool:
+    return BUSYBOX.is_file()
+
+
+def have_podman() -> bool:
+    return shutil.which("podman") is not None

--- a/test/test_ghcr.py
+++ b/test/test_ghcr.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Optional
+
+from fake_registry import (
+    FakeRegistry,
+    build_images,
+    have_busybox,
+    have_podman,
+    make_layer,
+)
+import pytest
+
+from tinuous.ghcr import (
+    DigestMismatch,
+    OCILayout,
+    digest_path,
+    download_image,
+    get_registry,
+)
+
+pytestmark = pytest.mark.skipif(
+    not have_busybox(), reason="/bin/busybox is needed to build test images"
+)
+
+
+@pytest.fixture(scope="module")
+def registry() -> Iterator[FakeRegistry]:
+    with FakeRegistry() as reg:
+        yield reg
+
+
+def pull(reg: FakeRegistry, name: str, dest: Path, reference: str = "latest") -> str:
+    client = get_registry(reg.hostname, insecure=True)
+    return download_image(client, reg.image_ref(name, reference), dest, tag=reference)
+
+
+def blobs(dest: Path) -> list[str]:
+    return sorted(p.name for p in (dest / "blobs" / "sha256").iterdir())
+
+
+@pytest.mark.parametrize(
+    "name", ["testorg/single", "testorg/multi", "testorg/notebooks/nested"]
+)
+def test_layout_is_valid(registry: FakeRegistry, tmp_path: Path, name: str) -> None:
+    dest = tmp_path / name.replace("/", "_")
+    digest = pull(registry, name, dest)
+    assert json.loads((dest / "oci-layout").read_text()) == {
+        "imageLayoutVersion": "1.0.0"
+    }
+    index = json.loads((dest / "index.json").read_text())
+    assert index["schemaVersion"] == 2
+    (entry,) = index["manifests"]
+    assert entry["digest"] == digest
+    assert entry["annotations"] == {"org.opencontainers.image.ref.name": "latest"}
+    assert entry["size"] == digest_path(dest, digest).stat().st_size
+    assert entry["mediaType"] == json.loads(
+        digest_path(dest, digest).read_bytes()
+    )["mediaType"]
+
+
+@pytest.mark.parametrize(
+    "name", ["testorg/single", "testorg/multi", "testorg/notebooks/nested"]
+)
+def test_all_blobs_present_and_verified(
+    registry: FakeRegistry, tmp_path: Path, name: str
+) -> None:
+    """Every blob is on disk, and every blob hashes to the name it is under."""
+    import hashlib
+
+    dest = tmp_path / name.replace("/", "_")
+    pull(registry, name, dest)
+    stored = set(blobs(dest))
+    assert stored == {d.partition(":")[2] for d in registry.images[name].blobs}
+    for encoded in stored:
+        path = dest / "blobs" / "sha256" / encoded
+        assert hashlib.sha256(path.read_bytes()).hexdigest() == encoded
+
+
+def test_manifest_bytes_are_stored_verbatim(
+    registry: FakeRegistry, tmp_path: Path
+) -> None:
+    """
+    The manifest must be stored exactly as served.  Reserializing the JSON
+    changes the digest, and an archive whose digests do not match the registry
+    cannot be verified against it or restored under its original references.
+    """
+    dest = tmp_path / "testorg/single"
+    digest = pull(registry, "testorg/single", dest)
+    served = registry.images["testorg/single"].blobs[digest]
+    assert digest_path(dest, digest).read_bytes() == served
+    reserialized = json.dumps(
+        json.loads(served), separators=(",", ":"), sort_keys=True
+    ).encode()
+    assert reserialized != served, "test image would not catch reserialization"
+
+
+def test_multiarch_pulls_every_sub_manifest(
+    registry: FakeRegistry, tmp_path: Path
+) -> None:
+    dest = tmp_path / "testorg/multi"
+    digest = pull(registry, "testorg/multi", dest)
+    index = json.loads(digest_path(dest, digest).read_bytes())
+    assert len(index["manifests"]) == 2
+    for entry in index["manifests"]:
+        manifest = json.loads(digest_path(dest, entry["digest"]).read_bytes())
+        for blob in [manifest["config"], *manifest["layers"]]:
+            assert digest_path(dest, blob["digest"]).exists()
+
+
+def test_pull_by_digest(registry: FakeRegistry, tmp_path: Path) -> None:
+    digest = registry.images["testorg/single"].tags["latest"]
+    dest = tmp_path / "bydigest"
+    assert pull(registry, "testorg/single", dest, digest) == digest
+
+
+def test_shared_blobs_downloaded_once(
+    registry: FakeRegistry, tmp_path: Path
+) -> None:
+    """Both platforms of the multi-arch image share a layer; fetch it once."""
+    dest = tmp_path / "testorg/multi"
+    mark = len(registry.requests)
+    pull(registry, "testorg/multi", dest)
+    blob_requests = [p for p in registry.requests[mark:] if "/blobs/" in p]
+    assert blob_requests
+    assert len(blob_requests) == len(set(blob_requests))
+
+
+def test_redownload_skipped_and_resumed(
+    registry: FakeRegistry, tmp_path: Path
+) -> None:
+    dest = tmp_path / "resume"
+    digest = pull(registry, "testorg/multi", dest)
+    before = blobs(dest)
+
+    # A complete layout is left alone.
+    assert pull(registry, "testorg/multi", dest) == digest
+    assert blobs(dest) == before
+
+    # A layout missing a platform manifest has that whole subtree fetched
+    # again, since a manifest blob is written only once its children are.
+    index = json.loads(digest_path(dest, digest).read_bytes())
+    digest_path(dest, index["manifests"][0]["digest"]).unlink()
+    assert pull(registry, "testorg/multi", dest) == digest
+    assert blobs(dest) == before
+
+
+def test_corrupt_blob_is_not_left_behind(tmp_path: Path) -> None:
+    """
+    A blob whose content does not match its digest is rejected and removed, so
+    that a later run does not mistake a truncated file for a complete one.
+    """
+    images = build_images()
+    single = images["testorg/single"]
+    manifest_digest = single.tags["latest"]
+    manifest = json.loads(single.blobs[manifest_digest])
+    layer_digest = manifest["layers"][0]["digest"]
+    single.blobs[layer_digest] = single.blobs[layer_digest][:-10]
+
+    dest = tmp_path / "corrupt"
+    with FakeRegistry(images) as reg:
+        with pytest.raises(DigestMismatch):
+            pull(reg, "testorg/single", dest)
+    assert not digest_path(dest, layer_digest).exists()
+    assert list((dest / "blobs" / "sha256").glob("*.tmp")) == []
+    # Without index.json the directory is not a layout, so an interrupted
+    # download is never mistaken for a complete image.
+    assert not OCILayout(dest).is_complete()
+
+
+def test_oci_media_types(tmp_path: Path) -> None:
+    """OCI-spelled media types work as well as the Docker ones GHCR serves."""
+    from fake_registry import Image
+
+    image = Image()
+    image.tag(
+        "latest", image.add_manifest("Built at: oci", "amd64", oci=True)["digest"]
+    )
+    dest = tmp_path / "oci"
+    with FakeRegistry({"testorg/oci": image}) as reg:
+        pull(reg, "testorg/oci", dest)
+    index = json.loads((dest / "index.json").read_text())
+    assert index["manifests"][0]["mediaType"] == (
+        "application/vnd.oci.image.manifest.v1+json"
+    )
+
+
+def test_unsupported_media_type(tmp_path: Path) -> None:
+    from fake_registry import Image, canonical
+
+    image = Image()
+    body = canonical({"schemaVersion": 1, "mediaType": "application/octet-stream"})
+    image.tag("latest", image.add("application/octet-stream", body)["digest"])
+    with FakeRegistry({"testorg/weird": image}) as reg:
+        with pytest.raises(ValueError, match="Unsupported manifest media type"):
+            pull(reg, "testorg/weird", tmp_path / "weird")
+
+
+def test_index_digest_of_incomplete_layout(tmp_path: Path) -> None:
+    assert OCILayout(tmp_path).index_digest() is None
+    (tmp_path / "index.json").write_text("not json")
+    assert OCILayout(tmp_path).index_digest() is None
+
+
+@pytest.mark.parametrize("digest", ["sha256", "sha256:", ":abc", "sha256:../escape"])
+def test_malformed_digest_rejected(tmp_path: Path, digest: str) -> None:
+    with pytest.raises(ValueError):
+        digest_path(tmp_path, digest)
+
+
+@pytest.mark.skipif(not have_podman(), reason="podman is not installed")
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("testorg/single", "single"),
+        ("testorg/multi", "multi"),
+        ("testorg/notebooks/nested", "nested"),
+    ],
+)
+def test_podman_can_run_the_layout(
+    registry: FakeRegistry, tmp_path: Path, name: str, expected: str
+) -> None:
+    """
+    The point of the exercise: hand the layout to podman and get the image to
+    run.  Also checks that the metadata file tinuous writes alongside does not
+    upset it.
+    """
+    dest = tmp_path / name.replace("/", "_")
+    pull(registry, name, dest)
+    (dest / "package.json").write_text('{"package_name": "test"}\n')
+    r = subprocess.run(
+        [shutil.which("podman") or "podman", "run", "--rm", f"oci:{dest}"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert r.returncode == 0, r.stderr
+    assert f"Built at: {expected}" in r.stdout
+
+
+def test_make_layer_is_reproducible() -> None:
+    assert make_layer("x") == make_layer("x")
+    assert make_layer("x") != make_layer("y")
+
+
+def test_credentials_are_exchanged_for_a_registry_token(tmp_path: Path) -> None:
+    """
+    A registry answers 401 with a challenge, and the credentials have to be
+    exchanged at the realm it names for a bearer token.  GHCR rejects a GitHub
+    token presented directly as a bearer, so getting this wrong means no image
+    is ever downloaded.
+    """
+    from fake_registry import CREDENTIALS, ISSUED_TOKEN
+
+    dest = tmp_path / "authed"
+    with FakeRegistry(require_auth=True) as reg:
+        client = get_registry(reg.hostname, token=CREDENTIALS[1], insecure=True)
+        download_image(client, reg.image_ref("testorg/single"), dest)
+    assert OCILayout(dest).is_complete()
+    assert any(p.startswith("/token") for p in reg.requests)
+    assert client.auth.token == ISSUED_TOKEN
+
+
+@pytest.fixture()
+def no_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    `oras` retries any failed request five times with an exponential backoff,
+    including a permanent authentication failure, which takes it a bit over two
+    minutes to give up on.  The tests are not interested in waiting.
+    """
+    import oras.decorator
+
+    monkeypatch.setattr(oras.decorator.time, "sleep", lambda _seconds: None)
+
+
+@pytest.mark.usefixtures("no_backoff")
+@pytest.mark.parametrize("token", [None, "wrong"])
+def test_unusable_credentials_are_rejected(
+    tmp_path: Path, token: Optional[str]
+) -> None:
+    """
+    Neither anonymous access nor a bad password gets an image out of a registry
+    that requires authentication, and neither leaves a layout behind.
+    """
+    dest = tmp_path / "denied"
+    with FakeRegistry(require_auth=True) as reg:
+        client = get_registry(reg.hostname, token=token, insecure=True)
+        with pytest.raises(Exception):
+            download_image(client, reg.image_ref("testorg/single"), dest)
+    assert not OCILayout(dest).is_complete()

--- a/test/test_ghcr.py
+++ b/test/test_ghcr.py
@@ -24,14 +24,17 @@ from tinuous.ghcr import (
     get_registry,
 )
 
-pytestmark = pytest.mark.skipif(
-    not have_busybox(), reason="/bin/busybox is needed to build test images"
-)
-
 
 @pytest.fixture(scope="module")
 def registry() -> Iterator[FakeRegistry]:
     with FakeRegistry() as reg:
+        yield reg
+
+
+@pytest.fixture(scope="module")
+def runnable_registry() -> Iterator[FakeRegistry]:
+    """A registry whose images have a shell in them, for the podman tests"""
+    with FakeRegistry(build_images(runnable=True)) as reg:
         yield reg
 
 
@@ -214,6 +217,7 @@ def test_malformed_digest_rejected(tmp_path: Path, digest: str) -> None:
 
 
 @pytest.mark.skipif(not have_podman(), reason="podman is not installed")
+@pytest.mark.skipif(not have_busybox(), reason="a static busybox is needed")
 @pytest.mark.parametrize(
     "name,expected",
     [
@@ -223,7 +227,7 @@ def test_malformed_digest_rejected(tmp_path: Path, digest: str) -> None:
     ],
 )
 def test_podman_can_run_the_layout(
-    registry: FakeRegistry, tmp_path: Path, name: str, expected: str
+    runnable_registry: FakeRegistry, tmp_path: Path, name: str, expected: str
 ) -> None:
     """
     The point of the exercise: hand the layout to podman and get the image to
@@ -231,7 +235,7 @@ def test_podman_can_run_the_layout(
     upset it.
     """
     dest = tmp_path / name.replace("/", "_")
-    pull(registry, name, dest)
+    pull(runnable_registry, name, dest)
     (dest / "package.json").write_text('{"package_name": "test"}\n')
     r = subprocess.run(
         [shutil.which("podman") or "podman", "run", "--rm", f"oci:{dest}"],
@@ -290,6 +294,6 @@ def test_unusable_credentials_are_rejected(
     dest = tmp_path / "denied"
     with FakeRegistry(require_auth=True) as reg:
         client = get_registry(reg.hostname, token=token, insecure=True)
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="Cannot respond to request"):
             download_image(client, reg.image_ref("testorg/single"), dest)
     assert not OCILayout(dest).is_complete()

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any, Optional
 
-from fake_registry import FakeRegistry, have_busybox
+from fake_registry import FakeRegistry
 import pytest
 import requests
 from yaml import safe_load
@@ -48,13 +48,15 @@ PACKAGES = [
 
 
 def version(
-    id: int, tags: list[str], updated: str = "2026-08-20T00:00:00Z"
+    version_id: int, tags: list[str], updated: str = "2026-08-20T00:00:00Z"
 ) -> dict[str, Any]:
     return {
-        "id": id,
-        "name": f"sha256:{id:064x}",
-        "url": f"{ORG}/packages/container/dandi-api/versions/{id}",
-        "html_url": f"https://github.com/dandi/dandi-archive/pkgs/container/x/{id}",
+        "id": version_id,
+        "name": f"sha256:{version_id:064x}",
+        "url": f"{ORG}/packages/container/dandi-api/versions/{version_id}",
+        "html_url": (
+            f"https://github.com/dandi/dandi-archive/pkgs/container/x/{version_id}"
+        ),
         "created_at": updated,
         "updated_at": updated,
         "metadata": {"package_type": "container", "container": {"tags": tags}},
@@ -88,12 +90,14 @@ def make_ci(
         self: GitHubActions, path: str, params: Optional[dict] = None
     ) -> Any:
         if path.endswith("/packages"):
+            assert params == {"package_type": "container"}
             if path.startswith("/orgs/") and org_status != 200:
                 raise http_error(org_status, path)
             if path.startswith("/users/"):
                 raise http_error(404, path)
             return iter(PACKAGES)
         assert "/versions" in path
+        assert params is None
         return iter(VERSIONS)
 
     monkeypatch.setattr(GitHubActions, "paginate", paginate)
@@ -223,7 +227,6 @@ def test_asset_path_untagged_falls_back_to_digest() -> None:
     assert asset.expand_path("{tag}", {}) == "sha256%3a" + "ab" * 32
 
 
-@pytest.mark.skipif(not have_busybox(), reason="/bin/busybox is needed")
 def test_asset_download_and_reuse(tmp_path: Path) -> None:
     with FakeRegistry() as reg:
         client = get_registry(reg.hostname, insecure=True)

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+from fake_registry import FakeRegistry, have_busybox
+import pytest
+import requests
+from yaml import safe_load
+
+from tinuous.base import PackageSpec
+from tinuous.config import Config
+from tinuous.ghcr import get_registry
+from tinuous.github import GHPackageAsset, GitHubActions, Package, PackageVersion
+
+ORG = "https://api.github.com/orgs/dandi"
+
+PACKAGES = [
+    {
+        "id": 1,
+        "name": "example-notebooks/000409-ibl",
+        "package_type": "container",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-08-20T00:00:00Z",
+        "url": f"{ORG}/packages/container/example-notebooks%2F000409-ibl",
+        "repository": {"full_name": "dandi/example-notebooks"},
+    },
+    {
+        "id": 2,
+        "name": "dandi-api",
+        "package_type": "container",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-08-20T00:00:00Z",
+        "url": f"{ORG}/packages/container/dandi-api",
+        "repository": {"full_name": "dandi/dandi-archive"},
+    },
+    {
+        "id": 3,
+        "name": "orphan",
+        "package_type": "container",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-08-20T00:00:00Z",
+        "url": f"{ORG}/packages/container/orphan",
+    },
+]
+
+
+def version(
+    id: int, tags: list[str], updated: str = "2026-08-20T00:00:00Z"
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "name": f"sha256:{id:064x}",
+        "url": f"{ORG}/packages/container/dandi-api/versions/{id}",
+        "html_url": f"https://github.com/dandi/dandi-archive/pkgs/container/x/{id}",
+        "created_at": updated,
+        "updated_at": updated,
+        "metadata": {"package_type": "container", "container": {"tags": tags}},
+    }
+
+
+VERSIONS = [
+    version(10, ["latest", "v2"]),
+    version(11, [], "2026-08-19T00:00:00Z"),
+    version(12, ["v1"], "2026-01-05T00:00:00Z"),
+]
+
+
+def make_ci(
+    monkeypatch: pytest.MonkeyPatch,
+    package_spec: Optional[PackageSpec] = None,
+    since: str = "2020-01-01T00:00:00Z",
+    org_status: int = 200,
+) -> GitHubActions:
+    from tinuous.base import GHWorkflowSpec
+
+    ci = GitHubActions(
+        repo="dandi/dandi-archive",
+        token="not-a-real-token",
+        since=datetime.fromisoformat(since.replace("Z", "+00:00")),
+        workflow_spec=GHWorkflowSpec(),
+        package_spec=package_spec or PackageSpec(),
+    )
+
+    def paginate(
+        self: GitHubActions, path: str, params: Optional[dict] = None
+    ) -> Any:
+        if path.endswith("/packages"):
+            if path.startswith("/orgs/") and org_status != 200:
+                raise http_error(org_status, path)
+            if path.startswith("/users/"):
+                raise http_error(404, path)
+            return iter(PACKAGES)
+        assert "/versions" in path
+        return iter(VERSIONS)
+
+    monkeypatch.setattr(GitHubActions, "paginate", paginate)
+    return ci
+
+
+def http_error(status: int, url: str) -> requests.HTTPError:
+    response = requests.Response()
+    response.status_code = status
+    response.url = url
+    return requests.HTTPError(f"{status} for {url}", response=response)
+
+
+def test_package_owner_and_repo() -> None:
+    pkg = Package.model_validate(PACKAGES[0])
+    assert pkg.owner_endpoint == "/orgs/dandi"
+    assert pkg.owner == "dandi"
+    assert pkg.repo_name == "dandi/example-notebooks"
+    assert Package.model_validate(PACKAGES[2]).repo_name is None
+
+
+def test_package_version_tags() -> None:
+    assert PackageVersion.model_validate(VERSIONS[0]).tags == ["latest", "v2"]
+    assert PackageVersion.model_validate(VERSIONS[1]).tags == []
+    stripped = dict(VERSIONS[0], metadata=None)
+    assert PackageVersion.model_validate(stripped).tags == []
+
+
+def test_packages_scoped_to_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    The API only lists packages per owner.  dandi's containers all belong to
+    dandi/example-notebooks, so a backup of dandi/dandi-archive must not drag
+    them in.
+    """
+    ci = make_ci(monkeypatch)
+    assert [p.name for p in ci.get_packages()] == ["dandi-api"]
+
+
+def test_packages_owner_wide(monkeypatch: pytest.MonkeyPatch) -> None:
+    ci = make_ci(monkeypatch, PackageSpec(owner_wide=True))
+    assert [p.name for p in ci.get_packages()] == [
+        "example-notebooks/000409-ibl",
+        "dandi-api",
+        "orphan",
+    ]
+
+
+def test_packages_falls_back_to_user_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ci = make_ci(monkeypatch, org_status=404)
+    assert list(ci.get_packages()) == []
+
+
+def test_packages_missing_scope_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ci = make_ci(monkeypatch, org_status=403)
+    with pytest.raises(RuntimeError, match="read:packages"):
+        list(ci.get_packages())
+
+
+def test_package_assets_skip_untagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    ci = make_ci(monkeypatch)
+    assert [a.version_id for a in ci.get_package_assets()] == [10, 12]
+
+    ci = make_ci(monkeypatch, PackageSpec(untagged=True))
+    assert [a.version_id for a in ci.get_package_assets()] == [10, 11, 12]
+
+
+def test_package_assets_respect_since_and_until(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ci = make_ci(monkeypatch, since="2026-06-01T00:00:00Z")
+    assert [a.version_id for a in ci.get_package_assets()] == [10]
+
+    ci = make_ci(monkeypatch)
+    ci.until = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    assert [a.version_id for a in ci.get_package_assets()] == [12]
+
+
+def test_package_assets_respect_include(monkeypatch: pytest.MonkeyPatch) -> None:
+    ci = make_ci(
+        monkeypatch, PackageSpec.model_validate({"include": ["nope"], "regex": False})
+    )
+    assert list(ci.get_package_assets()) == []
+
+
+def make_asset(**kwargs: Any) -> GHPackageAsset:
+    fields: dict[str, Any] = {
+        "registry": get_registry("ghcr.io"),
+        "owner": "dandi",
+        "package_name": "example-notebooks/000409-ibl",
+        "package_type": "container",
+        "version_id": 10,
+        "digest": "sha256:" + "ab" * 32,
+        "tags": ["latest", "v2"],
+        "updated_at": datetime(2026, 8, 20, 12, 30, tzinfo=timezone.utc),
+        "html_url": None,
+    }
+    fields.update(kwargs)
+    return GHPackageAsset(**fields)
+
+
+def test_asset_image_reference() -> None:
+    asset = make_asset()
+    assert asset.image == (
+        "ghcr.io/dandi/example-notebooks/000409-ibl@sha256:" + "ab" * 32
+    )
+
+
+def test_asset_path_expansion() -> None:
+    asset = make_asset()
+    path = asset.expand_path("{year}/{month}/{ci}/{package_name}/{digest}/", {})
+    # Slashes and colons are escaped so that a package name or digest cannot
+    # introduce extra path components.
+    assert path == (
+        "2026/08/github/example-notebooks%2f000409-ibl/sha256%3a" + "ab" * 32 + "/"
+    )
+    assert asset.expand_path("{tag}/{tags}/{version_id}/{type}", {}) == (
+        "latest/latest,v2/10/package"
+    )
+
+
+def test_asset_path_untagged_falls_back_to_digest() -> None:
+    asset = make_asset(tags=[])
+    assert asset.expand_path("{tag}", {}) == "sha256%3a" + "ab" * 32
+
+
+@pytest.mark.skipif(not have_busybox(), reason="/bin/busybox is needed")
+def test_asset_download_and_reuse(tmp_path: Path) -> None:
+    with FakeRegistry() as reg:
+        client = get_registry(reg.hostname, insecure=True)
+        digest = reg.images["testorg/notebooks/nested"].tags["latest"]
+        asset = make_asset(
+            registry=client,
+            owner="testorg",
+            package_name="notebooks/nested",
+            digest=digest,
+        )
+        assert asset.image == f"{reg.hostname}/testorg/notebooks/nested@{digest}"
+
+        dest = tmp_path / "pkg"
+        paths = asset.download(dest)
+        assert paths
+        metadata = json.loads((dest / "package.json").read_text())
+        assert metadata["digest"] == digest
+        assert metadata["tags"] == ["latest", "v2"]
+        assert metadata["package_name"] == "notebooks/nested"
+        assert metadata["image"] == asset.image
+
+        # A second run over a complete layout downloads nothing.
+        assert asset.download(dest) == []
+
+        # A version whose digest differs replaces the layout in place, which is
+        # what happens when a path template keyed on `{tag}` sees a moved tag.
+        other = reg.images["testorg/multi"].tags["latest"]
+        asset2 = make_asset(
+            registry=client, owner="testorg", package_name="multi", digest=other
+        )
+        dest2 = tmp_path / "moved"
+        asset.download(dest2)
+        assert asset2.download(dest2)
+        index = json.loads((dest2 / "index.json").read_text())
+        assert index["manifests"][0]["digest"] == other
+
+
+def test_config_accepts_package_options() -> None:
+    cfg = Config.model_validate(
+        safe_load(
+            """
+repo: dandi/example-notebooks
+ci:
+  github:
+    paths:
+      packages: '{year}/{month}/{ci}/packages/{package_name}/{digest}/'
+    packages:
+      include:
+        - '0004.*'
+      exclude:
+        - '.*-test'
+      regex: true
+      owner_wide: true
+      untagged: true
+"""
+        )
+    )
+    ghcfg = cfg.ci.github
+    assert ghcfg is not None
+    assert ghcfg.gets_packages()
+    assert ghcfg.packages.owner_wide
+    assert ghcfg.packages.untagged
+    assert ghcfg.packages.match("000409-ibl")
+    assert not ghcfg.packages.match("000409-test")
+    assert not ghcfg.packages.match("dandi-api")
+
+
+def test_config_package_list_shorthand() -> None:
+    cfg = Config.model_validate(
+        safe_load(
+            """
+repo: con/tinuous
+ci:
+  github:
+    paths:
+      packages: '{package_name}/{digest}/'
+    packages:
+      - tinuous-inception
+"""
+        )
+    )
+    ghcfg = cfg.ci.github
+    assert ghcfg is not None
+    assert ghcfg.packages.match("tinuous-inception")
+    assert not ghcfg.packages.match("something-else")
+    assert not ghcfg.packages.owner_wide
+    assert not ghcfg.packages.untagged
+
+
+def test_config_without_packages_path() -> None:
+    cfg = Config.model_validate(
+        safe_load("repo: con/tinuous\nci:\n  github:\n    paths:\n      logs: 'l/'\n")
+    )
+    ghcfg = cfg.ci.github
+    assert ghcfg is not None
+    assert not ghcfg.gets_packages()
+    assert ghcfg.packages.match("anything")


### PR DESCRIPTION
An alternative to #222 for #217. Opened separately rather than pushed onto that branch so the two can be compared; close whichever loses.

## Why not #222

Reviewing #222 first, the container-download path added in its last commit has never run successfully — the PR has zero check runs, and its integration test fails immediately. Three defects each independently prevent any image from being downloaded:

- **The registry auth is wrong.** It sends `Authorization: Bearer <raw GitHub PAT>` to `ghcr.io`, reusing the `api.github.com` client. GHCR does not accept a raw PAT as a bearer token, and an invalid header gets a `403 DENIED` rather than an anonymous fallback, even for public images:
  ```
  ghcr.io/v2/con/tinuous-inception/manifests/latest   (public)
    no Authorization -> 401
    bogus bearer     -> 403 DENIED
  ```
  The failure is caught and logged at `log.debug`, so a run reports "N package versions saved" while having written only a stub JSON file.
- **Multi-arch images download zero layers.** Sub-manifests are fetched with `GET /v2/<img>/blobs/<digest>`; manifests are not blobs. Against a real dandi image that returns `404 BLOB_UNKNOWN`. Every dandi package is multi-arch.
- **The stored manifest digest is fabricated.** The manifest JSON is reserialized with `sort_keys=True` before hashing, so the archived digest is not the upstream digest and the copy can never be verified against, or restored under, its original reference.

Beyond that: a `403` from `/orgs/{owner}/packages` (a token without `read:packages`, which includes the Actions `GITHUB_TOKEN`) is not caught and aborts the whole `fetch`, logs and artifacts included; the package listing is org-wide with no repo scoping; and the integration test `os.chdir`s into a deleted temporary directory, which breaks 7 unrelated tests in `test_state.py`.

## Approach

I looked for a Python library rather than shelling out to `skopeo`.

| | verdict |
|---|---|
| **[`oras`](https://github.com/oras-project/oras-py)** (oras-py) | **chosen.** Official Python SDK of the ORAS project, Apache-2.0, actively released, pure Python (`requests` + `jsonschema`). Handles image references, credentials, and the `WWW-Authenticate` token exchange. |
| [`python-dxf`](https://github.com/davedoesdev/dxf) | rejected — will not install: its `www-authenticate` dependency fails to build on current setuptools. No layout support, no manifest-list recursion. |
| `docker` / `podman-py` | rejected — need a running daemon. |
| `containerregistry` (Google) | rejected — unmaintained, Bazel-oriented. |

`oras` ships an OCI layout puller (`oras.layout.NewLayoutFromRegistry`) that does almost exactly what is wanted, and does the things #222 got wrong correctly — verbatim manifest bytes, `Docker-Content-Digest`, recursive index walk. It cannot be used as-is: it dispatches only on the OCI media types, and GHCR serves the Docker spellings for anything pushed by `docker buildx`, which is both of our targets:

```
ValueError: Unsupported manifest mediaType:
  application/vnd.docker.distribution.manifest.list.v2+json
```

So this PR uses `oras` for the part that is genuinely subtle and well-tested — the registry client and the auth dance — and keeps the manifest walk in tinuous (`src/tinuous/ghcr.py`, ~130 lines of logic). That also lets the walk own things a backup tool wants and the library does not do: digest verification, atomic blob writes, and a completeness marker.

Both gaps are being taken upstream so this module can shrink later: the media-type dispatch (unreported; also affects `push_to_registry`, where a partial fix would silently upload manifests as plain blobs), and blob/manifest digest verification (already filed upstream as [oras-py#247](https://github.com/oras-project/oras-py/issues/247)).

## What it does

`paths.packages` gets a template; each package version is saved as an OCI image layout:

```yaml
ci:
  github:
    paths:
      packages: '{year}/{month}/{ci}/packages/{package_name}/{digest}/'
    packages:
      include: ['tinuous-.*']
      regex: true
      owner_wide: false   # default: only this repository's packages
      untagged: false     # default: skip buildx intermediates and attestations
```

```console
$ podman run oci:2026/08/github/packages/tinuous-inception/sha256%3a530a02.../
Built at: 2026-01-06 20:30:58 UTC
```

Correctness properties, each covered by a test:

- Credentials are exchanged at the realm the registry names; the resulting bearer token is what is presented.
- Manifests are stored byte-for-byte as served, so archived digests are upstream digests.
- Image indexes are walked recursively via the manifest endpoint; every platform's manifest, config, and layers are stored.
- Blobs stream to a `.tmp` file, are hashed, and are moved into place only on a match; a failure removes the partial file rather than leaving something a later run mistakes for complete.
- `index.json` is written last, so an interrupted download is not a valid layout and is redone.
- Images are pulled by digest, not tag, so a tag moving mid-run cannot substitute a different image.
- A version already on disk is skipped; one whose digest differs replaces the layout, so a `{tag}`-keyed path keeps up with a moved tag instead of freezing on the first image it saw.
- Blobs shared between platforms are fetched once.

Failure modes are loud: a token without `read:packages` gets `RuntimeError: ... a token with the 'read:packages' scope is needed`, not a silent empty result.

### Repo scoping

GitHub only lists packages per owner. `https://github.com/orgs/dandi/packages` has ~33 container packages and **all of them belong to `dandi/example-notebooks`**, so with #222's org-wide listing a backup of any other dandi repo would try to pull all of them. Here the default is to fetch only packages whose `repository.full_name` matches the configured repo; `owner_wide: true` opts into the old behaviour.

### Volume

`dandi/example-notebooks/001550-paganlab` is 908 MB across its two platforms and carries 20 tags. Versions of a package share most of their layers; inside a DataLad dataset git-annex stores each layer once regardless of how many versions reference it. Documented in the README.

## Testing

`test/fake_registry.py` is an in-process registry serving images built from `/bin/busybox` — single-platform, multi-platform, and a nested name like dandi's, in both Docker and OCI media types, optionally behind a token challenge. Tests need no network and no credentials. Where podman and a static busybox are both present, three tests run `podman run oci:<layout>` and assert on the container's output; where they are not, only those three skip.

```
tox -e py:  109 passed        # 61 before this PR
            src/tinuous/ghcr.py  ~96% covered
            103 passed, 3 skipped    # on a machine with no busybox
flake8: clean
mypy:   Success: no issues found in 20 source files
```

Against the real registry, verified from a sandbox whose egress policy blocks GHCR's blob CDN (`pkg-containers.githubusercontent.com` — `skopeo copy` fails there identically), so layer *bytes* could not be transferred; blob downloads were replaced by an unredirected HEAD, which still proves each blob is reachable and the size the manifest claims. Everything else is the real code path:

| target | media type | manifests | blobs |
|---|---|---|---|
| `ghcr.io/con/tinuous-inception:latest` | `manifest.v2` | 1 | 4 — 3.9 MB |
| `ghcr.io/dandi/example-notebooks/001550-paganlab:latest` | `manifest.list.v2` | index + linux/amd64 + linux/arm64 | 30 — 908.1 MB |
| `ghcr.io/dandi/example-notebooks/000409-ibl:hash-064621cba038-arm64` | `manifest.v2` | 1 | 15 — 588.4 MB |

All three produced a complete layout whose `index.json` digest matched the digest the registry reported.

Two things could not be exercised here and want a real run before merge: the `/orgs/{owner}/packages` listing (my token lacks `read:packages`, so that path is covered only by unit tests against mocked responses), and a pull of a private package with a real token.

## CI

Green on `cc49949` — GitHub Actions (lint, typing, codespell, CPython 3.10–3.14, pypy-3.11, `test (base)`, `test (datalad)`), CircleCI, Codecov, and both AppVeyor builds. Coverage goes up: 60.49% → 66.00% (+5.51%).

For the record, since it was red for a while: on the pre-merge head this PR had four failing checks, all of which #233 resolved rather than anything in this branch. `test (base)`/`test (datalad)` were dying on `KeyError: 'next_page_token'` in `src/tinuous/circleci.py`, code this PR does not touch; the two pypy jobs could not build `pydantic-core` on PyPy < 3.11 and were red on `master` too. AppVeyor was also red and I could not diagnose it — `ci.appveyor.com` is unreachable from where I was working — and it went green once #233 dropped Python 3.9 from the AppVeyor matrix, which is consistent with the suspicion that it was the 3.9 job failing to resolve the new `oras`/`jsonschema` dependency chain (`jsonschema >= 4.26` needs 3.10, `rpds-py >= 2026` needs 3.11). That remains inferred, not proven — I never saw the log.