### PR TITLE
Merge Dependabot bumps, fix CI, test on 3.14 and drop 3.9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,6 @@ image: Ubuntu
 
 environment:
   matrix:
-    - PY: '3.9'
-      TOXENV: py
     - PY: '3.10'
       TOXENV: py
     - PY: '3.11'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,8 @@ environment:
       TOXENV: py
     - PY: '3.13'
       TOXENV: py
+    - PY: '3.14'
+      TOXENV: py
     - PY: '3.10'
       TOXENV: lint
     - PY: '3.10'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       - lint
       - typing
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,6 +17,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/inception-test.yml
+++ b/.github/workflows/inception-test.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 

--- a/.github/workflows/inception-test.yml
+++ b/.github/workflows/inception-test.yml
@@ -21,7 +21,7 @@ jobs:
           - datalad
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
           python -m pip install git-annex datalad
 
       - name: Checkout con/tinuous-inception
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: con/tinuous-inception
           path: tinuous-inception

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           chmod a+x ~/auto
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '^3.10'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
-          - 'pypy-3.9'
-          - 'pypy-3.10'
           - 'pypy-3.11'
         toxenv: [py]
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
           - 'pypy-3.11'
         toxenv: [py]
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             toxenv: typing
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 cache: pip
 dist: focal
 python:
-  - '3.9'
   - '3.10'
   - '3.11'
   - '3.12'
   - '3.13'
+  - '3.14'
 env:
   - TOXENV=py
 jobs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,11 +22,11 @@ classifiers =
     #Development Status :: 5 - Production/Stable
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: MIT License
@@ -41,7 +41,7 @@ project_urls =
 packages = find:
 package_dir =
     =src
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     click >= 7.0
     click-loglevel ~= 0.2

--- a/src/tinuous/circleci.py
+++ b/src/tinuous/circleci.py
@@ -57,7 +57,9 @@ class CircleCI(CISystem):
         while True:
             data = self.client.get(path, params=params).json()
             yield from data["items"]
-            next_page_token = data["next_page_token"]
+            # The API is documented as always returning "next_page_token", but
+            # it has been observed to omit the field on the last page.
+            next_page_token = data.get("next_page_token")
             if next_page_token is None:
                 break
             if params is None:

--- a/src/tinuous/circleci.py
+++ b/src/tinuous/circleci.py
@@ -59,8 +59,7 @@ class CircleCI(CISystem):
             yield from data["items"]
             # The API is documented as always returning "next_page_token", but
             # it has been observed to omit the field on the last page.
-            next_page_token = data.get("next_page_token")
-            if next_page_token is None:
+            if (next_page_token := data.get("next_page_token")) is None:
                 break
             if params is None:
                 params = {}

--- a/test/test_circleci.py
+++ b/test/test_circleci.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from tinuous.base import WorkflowSpec
+from tinuous.circleci import CircleCI
+
+
+class FakeResponse:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.data = data
+
+    def json(self) -> dict[str, Any]:
+        return self.data
+
+
+class FakeClient:
+    """Serves canned responses and records the params of each request."""
+
+    def __init__(self, pages: list[dict[str, Any]]) -> None:
+        self.pages = pages
+        self.requests: list[tuple[str, dict[str, str] | None]] = []
+
+    def get(self, path: str, params: dict[str, str] | None = None) -> FakeResponse:
+        self.requests.append((path, None if params is None else dict(params)))
+        return FakeResponse(self.pages[len(self.requests) - 1])
+
+
+def paginate(pages: list[dict[str, Any]]) -> tuple[list[dict], FakeClient]:
+    ci = CircleCI(
+        repo="con/tinuous",
+        token="hunter2",
+        since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        workflow_spec=WorkflowSpec(include=[], exclude=[], regex=False),
+    )
+    client = FakeClient(pages)
+    # Pre-seed the `client` cached_property so no real requests are made:
+    ci.__dict__["client"] = client
+    return list(ci.paginate("/v2/some/path")), client
+
+
+def test_paginate_stops_on_null_token() -> None:
+    items, client = paginate([{"items": [{"n": 1}], "next_page_token": None}])
+    assert items == [{"n": 1}]
+    assert client.requests == [("/v2/some/path", None)]
+
+
+def test_paginate_stops_on_missing_token() -> None:
+    # The API is documented as always returning "next_page_token", but it has
+    # been observed to omit the field entirely.
+    items, client = paginate([{"items": [{"n": 1}]}])
+    assert items == [{"n": 1}]
+    assert client.requests == [("/v2/some/path", None)]
+
+
+def test_paginate_follows_token() -> None:
+    items, client = paginate(
+        [
+            {"items": [{"n": 1}], "next_page_token": "tok1"},
+            {"items": [{"n": 2}]},
+        ]
+    )
+    assert items == [{"n": 1}, {"n": 2}]
+    assert client.requests == [
+        ("/v2/some/path", None),
+        ("/v2/some/path", {"page-token": "tok1"}),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,typing,py39,py310,py311,py312,py313
+envlist = lint,typing,py310,py311,py312,py313,py314
 skip_missing_interpreters = True
 isolated_build = True
 minversion = 3.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,typing,py38,py39,py310,py311,py312
+envlist = lint,typing,py39,py310,py311,py312,py313
 skip_missing_interpreters = True
 isolated_build = True
 minversion = 3.3.0


### PR DESCRIPTION
Merges the two open Dependabot PRs, fixes the three failures that had CI red, and moves the supported-version window from 3.9–3.13 to 3.10–3.14.

## Dependabot merges

Both open Dependabot PRs are included as real merge commits. Neither carries a `major` label — Dependabot labels these `internal` per `.github/dependabot.yml`:

| PR | Bump | Label |
|----|------|-------|
| #230 | `actions/checkout` 4 → 7 | `internal` |
| #231 | `actions/setup-python` 6 → 7 | `internal` |

Both branches were based on pre-#229 `master`, so a naive diff of either would have looked like it reverted `codecov/codecov-action` v7 → v6. Merging properly preserves **v7**, which is verified in the final diff (the codecov lines don't appear in it at all).

The `checkout` bump also clears the `Node.js 20 is deprecated` warnings that `actions/checkout@v4` was emitting on every job.

## CI fix 1 — `KeyError: 'next_page_token'`

Both `Test fetching tinuous' logs` jobs (`base` and `datalad`) were failing here:

```
File "tinuous/circleci.py", line 60, in paginate
    next_page_token = data["next_page_token"]
KeyError: 'next_page_token'
```

CircleCI's v2 API is documented as always returning `next_page_token` (null on the last page), but it has been observed to omit the field entirely. Pagination now ends on a missing field exactly as it does on an explicit null:

```python
if (next_page_token := data.get("next_page_token")) is None:
    break
```

Added `test/test_circleci.py` covering all three cases — null token, missing token, and following a token to a second page. Confirmed the tests reproduce the original `KeyError` when the fix is reverted, and pass with it applied.

## CI fix 2 — pypy-3.9 / pypy-3.10 build failures

The `test (pypy-3.9, py)` and `test (pypy-3.10, py)` jobs failed installing dependencies:

```
Building wheel for pydantic-core (pyproject.toml): finished with status 'error'
Failed to build pydantic-core
```

`pydantic-core` 2.46.4 — pinned by the current `pydantic ~= 2.0` resolution — publishes wheels for `cp39`–`cp314`, `graalpy311/312` and `pp311` only. With no `pp39`/`pp310` wheel, pip fell back to a Rust source build the runners can't complete. Dropped both; `pypy-3.11` has a wheel and is retained.

## CI fix 3 — AppVeyor

AppVeyor had been red repo-wide since well before this PR (identical failures on merged #229 and on #231, a pure `setup-python` bump). Per maintainer diagnosis the cause was the Python 3.9 matrix entry: AppVeyor's Ubuntu image no longer ships the preinstalled `$HOME/venv3.9` this config depends on now that 3.9 is EOL, and that single entry failed the whole build.

## Version window: 3.10 – 3.14

Rather than keep a version only some CI systems could still exercise, 3.9 is dropped outright and 3.14 added, consistently across **every** matrix:

| Location | Before | After |
|---|---|---|
| `.github/workflows/test.yml` | 3.9–3.13, pypy 3.9/3.10/3.11 | 3.10–3.14, pypy-3.11 |
| `.appveyor.yml` | 3.9–3.13 | 3.10–3.14 |
| `.circleci/config.yml` | 3.9–3.13 | 3.10–3.14 |
| `.travis.yml` | 3.9–3.13 | 3.10–3.14 |
| `tox.ini` envlist | py38–py312 | py310–py314 |
| `setup.cfg` | `python_requires >=3.9` | `python_requires >=3.10` |

Trove classifiers updated to match (3.9 removed, 3.14 added). `pydantic-core` already publishes a `cp314` wheel, so the one dependency needing compilation is covered on the new high end.

Two notes for the maintainer:

- **`.travis.yml` is updated for consistency** — it's a version matrix maintained in lockstep by the commit that dropped 3.8 — but Travis reports no status checks on this PR, so it appears inactive and its `dist: focal` image is unlikely to offer 3.14. Say the word if you'd rather leave it alone or retire it.
- **AppVeyor on 3.14 is unverified from my side.** Its image lacking a preinstalled venv is exactly what broke 3.9; whether `$HOME/venv3.14` exists there can only be settled by the run itself, since `ci.appveyor.com` is unreachable from my sandbox. If AppVeyor goes red on the 3.14 entry, that's the cause and removing just that entry is the fix.

## Validation

Ran the full CI check set locally against the merged branch:

- `pytest` — **67 passed** (64 existing + 3 new)
- `flake8 --config=tox.ini src test` — clean
- `mypy src test` — `Success: no issues found in 16 source files`
- `black --check` with the repo-pinned 23.3.0 — clean, all 15 files
- `isort --check-only` — clean
- `codespell` — clean
- `pip install -e .` succeeds under the bumped `python_requires`
- All four CI YAML files re-parsed after editing and their matrices asserted equal to 3.10–3.14

The inception-test job hits the live CircleCI API and AppVeyor can't be reached from here, so both are confirmed only by their own runs.

Since this carries a user-facing bug fix, `patch` is probably the right release label — `internal` alone would mean no release under `onlyPublishWithReleaseLabel`. If you consider the `python_requires` bump breaking, `major` would be the call instead.